### PR TITLE
websocket load test and set ws pipe to -1

### DIFF
--- a/src/Lime.Protocol.LoadTests/CustomTraceWriter.cs
+++ b/src/Lime.Protocol.LoadTests/CustomTraceWriter.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Lime.Protocol.Network;
+using Lime.Protocol.Serialization;
+using Lime.Protocol.Serialization.Newtonsoft;
+using Lime.Protocol.UnitTests;
+using Lime.Transport.Tcp;
+using Lime.Transport.WebSocket;
+using Shouldly;
+using Xunit;
+
+namespace Lime.Protocol.LoadTests
+{
+
+    public sealed class CustomTraceWriter : ITraceWriter
+    {
+        public CustomTraceWriter()
+        {
+        }
+
+        public Task TraceAsync(string data, DataOperation operation)
+        {
+            return Task.CompletedTask;
+        }
+
+        public bool IsEnabled => true;
+    }
+}

--- a/src/Lime.Protocol.LoadTests/FakeEnvelopeSerializer.cs
+++ b/src/Lime.Protocol.LoadTests/FakeEnvelopeSerializer.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Lime.Protocol.Serialization;
+using Lime.Protocol.Serialization.Newtonsoft;
+using Lime.Protocol.UnitTests;
+using Lime.Transport.Tcp;
+using Shouldly;
+using Xunit;
+
+namespace Lime.Protocol.LoadTests
+{
+
+    public sealed class FakeEnvelopeSerializer : IEnvelopeSerializer
+    {
+        private readonly Envelope[] _envelopes;
+        private readonly string[] _serializedEnvelopes;
+        private int _serializePos;
+        private int _deserializePos;
+
+        private readonly object _serializeSyncRoot = new object();
+        private readonly object _deserializeSyncRoot = new object();
+
+        public FakeEnvelopeSerializer(int count)
+        {
+            _envelopes = Enumerable
+                .Range(0, count)
+                .Select<int, Envelope>(i =>
+                {
+                    if (i % 5 == 0)
+                    {
+                        return Dummy.CreateNotification(Event.Received);
+                    }
+                    if (i % 3 == 0)
+                    {
+                        return Dummy.CreateCommand(Dummy.CreateAccount());
+                    }
+                    if (i % 2 == 0)
+                    {
+                        return Dummy.CreateMessage(Dummy.CreateTextContent());
+                    }
+                    return Dummy.CreateMessage(Dummy.CreateSelect());
+                })
+                .ToArray();
+
+            var jsonSerializer = new JsonNetSerializer();
+            _serializedEnvelopes = _envelopes.Select(e => jsonSerializer.Serialize(e)).ToArray();
+        }
+
+        public string Serialize(Envelope envelope)
+        {
+            lock (_serializeSyncRoot)
+            {
+                var value = _serializedEnvelopes[_serializePos];
+                _serializePos = (_serializedEnvelopes.Length + 1) % _serializedEnvelopes.Length;
+                return value;
+            }
+        }
+
+        public Envelope Deserialize(string envelopeString)
+        {
+            lock (_deserializeSyncRoot)
+            {
+                var value = _envelopes[_deserializePos];
+                _deserializePos = (_envelopes.Length + 1) % _envelopes.Length;
+                return value;
+            }
+        }
+    }
+}

--- a/src/Lime.Protocol.LoadTests/Lime.Protocol.LoadTests.csproj
+++ b/src/Lime.Protocol.LoadTests/Lime.Protocol.LoadTests.csproj
@@ -16,13 +16,14 @@
     <ProjectReference Include="..\Lime.Protocol.Serialization\Lime.Protocol.Serialization.csproj" />
     <ProjectReference Include="..\Lime.Transport.Tcp\Lime.Transport.Tcp.csproj" />
     <ProjectReference Include="..\Lime.Protocol.UnitTests\Lime.Protocol.UnitTests.csproj" />
+    <ProjectReference Include="..\Lime.Transport.WebSocket\Lime.Transport.WebSocket.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.2" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">


### PR DESCRIPTION
when we send many envelopes the websocket pipeline hangs, this PR set the pipeline to unbouded and also removes the json buffer usage since all the packets sent in the ws are complete json objects.

With the load test i got some random errors using the json buffer