### PR TITLE
websocket load test and set ws pipe to -1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,6 @@ before_build:
         $xml.Save($xmlPath)
     }
     UpdateProjectVersion "$env:appveyor_build_folder/src/Lime.Protocol/Lime.Protocol.csproj" $env:appveyor_build_version
-    UpdateProjectVersion "$env:appveyor_build_folder/src/Lime.Protocol.Serialization/Lime.Protocol.Serialization.csproj" $env:appveyor_build_version
     UpdateProjectVersion "$env:appveyor_build_folder/src/Lime.Messaging/Lime.Messaging.csproj" $env:appveyor_build_version
 
 - dotnet restore src/Lime.sln
@@ -30,13 +29,6 @@ build:
   parallel: true
   project: src/Lime.sln
   verbosity: normal
-after_build:
-- dotnet pack src/Lime.Protocol/Lime.Protocol.csproj --configuration Release /p:Version=%APPVEYOR_BUILD_VERSION%
-- dotnet pack src/Lime.Protocol.Serialization/Lime.Protocol.Serialization.csproj --configuration Release /p:Version=%APPVEYOR_BUILD_VERSION%
-- dotnet pack src/Lime.Messaging/Lime.Messaging.csproj --configuration Release /p:Version=%APPVEYOR_BUILD_VERSION%
-- dotnet pack src/Lime.Transport.Tcp/Lime.Transport.Tcp.csproj --configuration Release /p:Version=%APPVEYOR_BUILD_VERSION%
-- dotnet pack src/Lime.Transport.WebSocket/Lime.Transport.WebSocket.csproj --configuration Release /p:Version=%APPVEYOR_BUILD_VERSION%
-- dotnet pack src/Lime.Transport.Redis/Lime.Transport.Redis.csproj --configuration Release /p:Version=%APPVEYOR_BUILD_VERSION%
 test:
   assemblies:    
     - '**\*Tests.dll'

--- a/src/Lime.Protocol.LoadTests/CustomTraceWriter.cs
+++ b/src/Lime.Protocol.LoadTests/CustomTraceWriter.cs
@@ -1,0 +1,18 @@
+﻿using Lime.Protocol.Network;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Lime.Protocol.LoadTests
+{
+    public class CustomTraceWriter : ITraceWriter
+    {
+        public bool IsEnabled => true;
+
+        public Task TraceAsync(string data, DataOperation operation)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Lime.Protocol.LoadTests/FakeEnvelopeSerializer.cs
+++ b/src/Lime.Protocol.LoadTests/FakeEnvelopeSerializer.cs
@@ -1,0 +1,67 @@
+﻿using Lime.Protocol.Serialization;
+using Lime.Protocol.Serialization.Newtonsoft;
+using Lime.Protocol.UnitTests;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Lime.Protocol.LoadTests
+{
+    public sealed class FakeEnvelopeSerializer : IEnvelopeSerializer
+    {
+        private readonly Envelope[] _envelopes;
+        private readonly string[] _serializedEnvelopes;
+        private int _serializePos;
+        private int _deserializePos;
+
+        private readonly object _serializeSyncRoot = new object();
+        private readonly object _deserializeSyncRoot = new object();
+
+        public FakeEnvelopeSerializer(int count)
+        {
+            _envelopes = Enumerable
+                .Range(0, count)
+                .Select<int, Envelope>(i =>
+                {
+                    if (i % 5 == 0)
+                    {
+                        return Dummy.CreateNotification(Event.Received);
+                    }
+                    if (i % 3 == 0)
+                    {
+                        return Dummy.CreateCommand(Dummy.CreateAccount());
+                    }
+                    if (i % 2 == 0)
+                    {
+                        return Dummy.CreateMessage(Dummy.CreateTextContent());
+                    }
+                    return Dummy.CreateMessage(Dummy.CreateSelect());
+                })
+                .ToArray();
+
+            var jsonSerializer = new JsonNetSerializer();
+            _serializedEnvelopes = _envelopes.Select(e => jsonSerializer.Serialize(e)).ToArray();
+        }
+
+        public string Serialize(Envelope envelope)
+        {
+            lock (_serializeSyncRoot)
+            {
+                var value = _serializedEnvelopes[_serializePos];
+                _serializePos = (_serializedEnvelopes.Length + 1) % _serializedEnvelopes.Length;
+                return value;
+            }
+        }
+
+        public Envelope Deserialize(string envelopeString)
+        {
+            lock (_deserializeSyncRoot)
+            {
+                var value = _envelopes[_deserializePos];
+                _deserializePos = (_envelopes.Length + 1) % _envelopes.Length;
+                return value;
+            }
+        }
+    }
+}

--- a/src/Lime.Protocol.LoadTests/Lime.Protocol.LoadTests.csproj
+++ b/src/Lime.Protocol.LoadTests/Lime.Protocol.LoadTests.csproj
@@ -15,6 +15,7 @@
     <ProjectReference Include="..\Lime.Protocol\Lime.Protocol.csproj" />
     <ProjectReference Include="..\Lime.Transport.Tcp\Lime.Transport.Tcp.csproj" />
     <ProjectReference Include="..\Lime.Protocol.UnitTests\Lime.Protocol.UnitTests.csproj" />
+    <ProjectReference Include="..\Lime.Transport.WebSocket\Lime.Transport.WebSocket.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Lime.Transport.WebSocket/Lime.Transport.WebSocket.csproj
+++ b/src/Lime.Transport.WebSocket/Lime.Transport.WebSocket.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>Lime.Transport.WebSocket</AssemblyTitle>
     <VersionPrefix></VersionPrefix>
     <Authors>takenet;andrebires</Authors>
-    <TargetFrameworks>net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <AssemblyName>Lime.Transport.WebSocket</AssemblyName>
     <PackageId>Lime.Transport.WebSocket</PackageId>
     <PackageTags>lime</PackageTags>

--- a/src/Lime.Transport.WebSocket/WebSocketTransport.cs
+++ b/src/Lime.Transport.WebSocket/WebSocketTransport.cs
@@ -18,7 +18,7 @@ namespace Lime.Transport.WebSocket
 
         private readonly IEnvelopeSerializer _envelopeSerializer;
         private readonly ITraceWriter _traceWriter;
-        private readonly JsonBuffer _jsonBuffer;
+        private readonly byte[] _jsonBuffer;
         private readonly SemaphoreSlim _sendSemaphore;
         private readonly BufferBlock<Envelope> _receivedEnvelopeBufferBlock;
 
@@ -34,12 +34,12 @@ namespace Lime.Transport.WebSocket
             IEnvelopeSerializer envelopeSerializer,
             ITraceWriter traceWriter = null,
             int bufferSize = 8192,
-            int receiveBoundedCapacity = 5)
+            int receiveBoundedCapacity = -1)
         {
             WebSocket = webSocket;
             _envelopeSerializer = envelopeSerializer;
             _traceWriter = traceWriter;
-            _jsonBuffer = new JsonBuffer(bufferSize);
+            _jsonBuffer = new byte[bufferSize];
             _sendSemaphore = new SemaphoreSlim(1);
             CloseStatus = WebSocketCloseStatus.NormalClosure;
             CloseStatusDescription = string.Empty;
@@ -119,7 +119,7 @@ namespace Lime.Transport.WebSocket
                 {
                     try
                     {
-                        var buffer = new ArraySegment<byte>(_jsonBuffer.Buffer);
+                        var buffer = new ArraySegment<byte>(_jsonBuffer);
                         while (true)
                         {
                             var receiveResult =
@@ -137,23 +137,18 @@ namespace Lime.Transport.WebSocket
                                 throw new InvalidOperationException(CloseStatusDescription);
                             }
 
-                            _jsonBuffer.BufferCurPos += receiveResult.Count;
                             if (receiveResult.EndOfMessage) break;
                         }
 
-                        byte[] jsonBytes;
-                        if (_jsonBuffer.TryExtractJsonFromBuffer(out jsonBytes))
-                        {
-                            var envelopeJson = Encoding.UTF8.GetString(jsonBytes);
+                        var envelopeJson = Encoding.UTF8.GetString(buffer.Array);
 
-                            if (_traceWriter != null &&
-                                _traceWriter.IsEnabled)
-                            {
-                                await _traceWriter.TraceAsync(envelopeJson, DataOperation.Receive).ConfigureAwait(false);
-                            }
-                            var envelope = _envelopeSerializer.Deserialize(envelopeJson);
-                            await _receivedEnvelopeBufferBlock.SendAsync(envelope, cancellationToken);
+                        if (_traceWriter != null &&
+                            _traceWriter.IsEnabled)
+                        {
+                            await _traceWriter.TraceAsync(envelopeJson, DataOperation.Receive).ConfigureAwait(false);
                         }
+                        var envelope = _envelopeSerializer.Deserialize(envelopeJson);
+                        await _receivedEnvelopeBufferBlock.SendAsync(envelope, cancellationToken);
                     }
                     catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                     {
@@ -282,7 +277,6 @@ namespace Lime.Transport.WebSocket
         {
             if (disposing)
             {
-                _jsonBuffer.Dispose();
                 WebSocket.Dispose();
                 _sendSemaphore.Dispose();
                 _listenerCts?.Dispose();

--- a/src/Lime.Transport.WebSocket/WebSocketTransportListener.cs
+++ b/src/Lime.Transport.WebSocket/WebSocketTransportListener.cs
@@ -8,7 +8,9 @@ using Lime.Protocol;
 using Lime.Protocol.Network;
 using Lime.Protocol.Serialization;
 using Lime.Protocol.Server;
+#if net461
 using SslCertBinding.Net;
+#endif
 
 namespace Lime.Transport.WebSocket
 {
@@ -23,7 +25,7 @@ namespace Lime.Transport.WebSocket
         public static readonly Guid DefaultApplicationId = Guid.Parse("46754fc2-d8e2-4b41-a3f0-ed1878c77e59");
         public static readonly TimeSpan StopTimeout = TimeSpan.FromSeconds(30);
 
-        private readonly X509CertificateInfo _tlsCertificate; 
+        private readonly X509CertificateInfo _tlsCertificate;
         private readonly IEnvelopeSerializer _envelopeSerializer;
         private readonly ITraceWriter _traceWriter;
         private readonly int _bufferSize;
@@ -55,7 +57,7 @@ namespace Lime.Transport.WebSocket
         public WebSocketTransportListener(
             Uri listenerUri,
             X509CertificateInfo tlsCertificate,
-            IEnvelopeSerializer envelopeSerializer, 
+            IEnvelopeSerializer envelopeSerializer,
             ITraceWriter traceWriter = null,
             int bufferSize = 16384,
             TimeSpan? keepAliveInterval = null,
@@ -86,7 +88,7 @@ namespace Lime.Transport.WebSocket
             _applicationId = applicationId ?? DefaultApplicationId;
             _keepAliveInterval = keepAliveInterval ?? System.Net.WebSockets.WebSocket.DefaultKeepAliveInterval;
             _httpListener = new HttpListener();
-            
+
             var boundedCapacity = new ExecutionDataflowBlockOptions()
             {
                 BoundedCapacity = acceptTransportBoundedCapacity
@@ -123,10 +125,12 @@ namespace Lime.Transport.WebSocket
                 listenerUri.Scheme.Equals(UriSchemeWebSocketSecure))
             {
                 var ipPort = new IPEndPoint(IPAddress.Parse("0.0.0.0"), listenerUri.Port);
+#if net461
                 var config = new CertificateBindingConfiguration();
                 config.Bind(
                     new CertificateBinding(
                         _tlsCertificate.Thumbprint, _tlsCertificate.Store, ipPort, _applicationId));
+#endif
             }
 
             _httpListener.Start();


### PR DESCRIPTION
when we send many envelopes the websocket pipeline hangs, this PR set the pipeline to unbouded and also removes the json buffer usage since all the packets sent in the ws are complete json objects.

With the load test i got some random errors using the json buffer