### PR TITLE
Changed LimeUri ctor and created a unit test

### DIFF
--- a/src/Lime.Protocol.UnitTests/Lime.Protocol.UnitTests.csproj
+++ b/src/Lime.Protocol.UnitTests/Lime.Protocol.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <AssemblyName>Lime.Protocol.UnitTests</AssemblyName>
     <PackageId>Lime.Protocol.UnitTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>

--- a/src/Lime.Protocol.UnitTests/LimeUriTests.cs
+++ b/src/Lime.Protocol.UnitTests/LimeUriTests.cs
@@ -1,12 +1,12 @@
-﻿using System;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using Shouldly;
+using System;
 
 namespace Lime.Protocol.UnitTests
 {
     [TestFixture]
     public class LimeUriTests
-    {        
+    {
         [Test]
         public void Parse_ValidRelativeString_ReturnsInstance()
         {
@@ -33,6 +33,19 @@ namespace Lime.Protocol.UnitTests
         }
 
         [Test]
+        public void Parse_ValidEncodedAbsoluteString_ReturnsInstance()
+        {
+            var identity = "teste_it%C3%A1vel%3Axx@teste.net";
+            var resourceName = Dummy.CreateRandomString(10);
+            var absolutePath = string.Format("{0}://{1}/{2}", LimeUri.LIME_URI_SCHEME, identity, resourceName);
+            var actual = LimeUri.Parse(absolutePath);
+
+            actual.Path.ShouldNotBe(null);
+            actual.Path.ShouldBe(absolutePath);
+            actual.IsRelative.ShouldBe(false);
+        }
+
+        [Test]
         public void Parse_NullString_ThrowsArgumentNullException()
         {
             string path = null;
@@ -44,10 +57,9 @@ namespace Lime.Protocol.UnitTests
         public void Parse_InvalidRelativeString_ThrowsArgumentException()
         {
             var resourceName = Dummy.CreateRandomString(10);
-            var invalidPath = string.Format("\\{0}", resourceName);            
+            var invalidPath = string.Format("\\{0}", resourceName);
             Action action = () => LimeUri.Parse(invalidPath);
             action.ShouldThrow<ArgumentException>();
-
         }
 
         [Test]
@@ -65,7 +77,7 @@ namespace Lime.Protocol.UnitTests
             var resourceName = Dummy.CreateRandomString(10);
             var absolutePath = string.Format("{0}://{1}/{2}", LimeUri.LIME_URI_SCHEME, identity, resourceName);
             var limeUri = LimeUri.Parse(absolutePath);
-            
+
             // Act
             var uri = limeUri.ToUri();
 
@@ -120,6 +132,5 @@ namespace Lime.Protocol.UnitTests
             Action action = () => limeUri.ToUri(identity);
             action.ShouldThrow<InvalidOperationException>();
         }
-
     }
 }

--- a/src/Lime.Protocol/LimeUri.cs
+++ b/src/Lime.Protocol/LimeUri.cs
@@ -23,9 +23,8 @@ namespace Lime.Protocol
         {
             if (string.IsNullOrWhiteSpace(uriPath)) throw new ArgumentNullException(nameof(uriPath));
 
-            if (Uri.IsWellFormedUriString(uriPath, UriKind.Absolute))
+            if (Uri.TryCreate(uriPath, UriKind.Absolute, out _absoluteUri))
             {
-                _absoluteUri = new Uri(uriPath);
                 if (!_absoluteUri.Scheme.Equals(LIME_URI_SCHEME))
                 {
                     throw new ArgumentException($"Invalid URI scheme. Expected is '{LIME_URI_SCHEME}'");


### PR DESCRIPTION
The `Uri.IsWellFormedUriString` has different behaviour from net461, fixed using a workaround with `Uri.TryCreate` that accept `"lime://teste_it%C3%A1vel%3Axx@teste.net/8dd3a58vgv"`