### PR TITLE
change typeutil to ignore blank entries

### DIFF
--- a/src/Lime.Protocol.UnitTests/Serialization/TypeUtilTests.cs
+++ b/src/Lime.Protocol.UnitTests/Serialization/TypeUtilTests.cs
@@ -51,5 +51,17 @@ namespace Lime.Protocol.UnitTests.Serialization
             // Assert
             result.ShouldBe(100_000);
         }
+
+        [Test]
+        public void GetStringValue_EmptyStringToEmptyArray_ReturnEmptyArray()
+        {
+            object result = null;
+
+            //Act
+            TypeUtilEx.TryParseString("", typeof(string[]), out result, CultureInfo.InvariantCulture);
+
+            result.ShouldBeOfType(typeof(string[]));
+            ((string[])result).Length.ShouldBe(0);
+        }
     }
 }

--- a/src/Lime.Protocol.UnitTests/Serialization/TypeUtilTests.cs
+++ b/src/Lime.Protocol.UnitTests/Serialization/TypeUtilTests.cs
@@ -56,12 +56,12 @@ namespace Lime.Protocol.UnitTests.Serialization
         public void GetStringValue_EmptyStringToEmptyArray_ReturnEmptyArray()
         {
             object result = null;
-
             //Act
-            TypeUtilEx.TryParseString("", typeof(string[]), out result, CultureInfo.InvariantCulture);
+            TypeUtilEx.TryParseString(string.Empty, typeof(string[]), out result, CultureInfo.InvariantCulture);
 
-            result.ShouldBeOfType(typeof(string[]));
-            ((string[])result).Length.ShouldBe(0);
+            //Assert
+            var output = result.ShouldBeOfType<string[]>();
+            output.ShouldBeEmpty();
         }
     }
 }

--- a/src/Lime.Protocol/Serialization/TypeUtilEx.cs
+++ b/src/Lime.Protocol/Serialization/TypeUtilEx.cs
@@ -219,8 +219,8 @@ namespace Lime.Protocol.Serialization
             if (type.IsArray)
             {
                 var elementType = type.GetElementType();
-                var arrayValues = value.Split(';');
-                
+                var arrayValues = value.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+
                 var resultArray = Array.CreateInstance(elementType, arrayValues.Length);
 
                 for (int i = 0; i < arrayValues.Length; i++)

--- a/src/Lime.Protocol/Serialization/TypeUtilEx.cs
+++ b/src/Lime.Protocol/Serialization/TypeUtilEx.cs
@@ -18,7 +18,8 @@ namespace Lime.Protocol.Serialization
         private static readonly ConcurrentDictionary<Type, Func<string, object>> TypeParseFuncDictionary = new ConcurrentDictionary<Type, Func<string, object>>();
         private static readonly ConcurrentDictionary<Type, Func<string, IFormatProvider, object>> FormattedTypeParseFuncDictionary = new ConcurrentDictionary<Type, Func<string, IFormatProvider, object>>();
 
-        
+        private static readonly char[] ArraySeparator = new char[] { ';' };
+
         /// <summary>
         /// Gets the Parse static method of a Type as a func.
         /// </summary>
@@ -219,7 +220,7 @@ namespace Lime.Protocol.Serialization
             if (type.IsArray)
             {
                 var elementType = type.GetElementType();
-                var arrayValues = value.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+                var arrayValues = value.Split(ArraySeparator, StringSplitOptions.RemoveEmptyEntries);
 
                 var resultArray = Array.CreateInstance(elementType, arrayValues.Length);
 


### PR DESCRIPTION
Actually, when we have an empty string in a configuration property value, this class is generating an array with one element, but this element are coming empty.

This pull request are changing the split method, to pass the NonEmptyEntries, to create an array with zero elements.