### PR TITLE
Feature/changing contact group location

### DIFF
--- a/src/Lime.Messaging/Resources/Contact.cs
+++ b/src/Lime.Messaging/Resources/Contact.cs
@@ -18,7 +18,6 @@ namespace Lime.Messaging.Resources
         public const string SHARE_PRESENCE_KEY = "sharePresence";
         public const string SHARE_ACCOUNT_INFO_KEY = "shareAccountInfo";
         public const string PRIORITY_KEY = "priority";
-        public const string GROUP_KEY = "group";
         public const string LAST_MESSAGE_DATE = "lastMessageDate";
 
         /// <summary>
@@ -67,12 +66,6 @@ namespace Lime.Messaging.Resources
         /// </value>
         [DataMember(Name = PRIORITY_KEY, EmitDefaultValue = false)]
         public int? Priority { get; set; }
-
-        /// <summary>
-        /// Indicates the contact group.
-        /// </summary>
-        [DataMember(Name = GROUP_KEY, EmitDefaultValue = false)]
-        public string Group { get; set; }
 
         /// <summary>
         /// Indicates the last message received or sent date off the contact.

--- a/src/Lime.Messaging/Resources/ContactDocument.cs
+++ b/src/Lime.Messaging/Resources/ContactDocument.cs
@@ -30,6 +30,7 @@ namespace Lime.Messaging.Resources
         public const string BIRTH_DATE_KEY = "birthDate";
         public const string TAX_DOCUMENT_KEY = "taxDocument";
         public const string CREATION_DATE_KEY = "creationDate";
+        public const string GROUP_KEY = "group";
 
 
         /// <summary>
@@ -150,6 +151,12 @@ namespace Lime.Messaging.Resources
         /// </summary>
         [DataMember(Name = CREATION_DATE_KEY)]
         public DateTimeOffset? CreationDate { get; set; }
+
+        /// <summary>
+        /// Indicates the contact group.
+        /// </summary>
+        [DataMember(Name = GROUP_KEY, EmitDefaultValue = false)]
+        public string Group { get; set; }
     }
 
     /// <summary>


### PR DESCRIPTION
This PR proposal is make possible to send the contact group from some domain to another one. To do it, we are moving the `Group` properties from `Contact` to `ContactDocument`. 