### PR TITLE
[FEATURE] Implement Dark Mode and solving Json Field Bugs

### DIFF
--- a/src/Lime.Client.TestConsole/App.xaml
+++ b/src/Lime.Client.TestConsole/App.xaml
@@ -21,6 +21,7 @@
                 <Setter Property="BorderThickness"  Value="0" />
                 <Setter Property="TextWrapping" Value="Wrap" />
                 <Setter Property="FontFamily" Value="Courier New" />
+                <Setter Property="Background" Value="Transparent" />                
             </Style>
             
             <vm:MainViewModel x:Key="MainViewModel" />

--- a/src/Lime.Client.TestConsole/Converters/DataOperationToBrushConverter.cs
+++ b/src/Lime.Client.TestConsole/Converters/DataOperationToBrushConverter.cs
@@ -4,29 +4,44 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Data;
 using System.Windows.Media;
 
 namespace Lime.Client.TestConsole.Converters
 {
-    public class DataOperationToBrushConverter : IValueConverter
+    public class DataOperationToBrushConverter : IMultiValueConverter
     {
+
+        private readonly SolidColorBrush LightDarkMode = (SolidColorBrush)(new BrushConverter().ConvertFrom("#1e1e1e"));
+        private readonly SolidColorBrush NormalDarkMode = (SolidColorBrush)(new BrushConverter().ConvertFrom("#252526"));
+
         #region IValueConverter Members
 
-        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        public object Convert(object[] values, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            if (value is DataOperation)
+            //First value is Direction property
+            //Second value is IsDarkMode property
+
+            if (values[0] is DataOperation && ((DataOperation)values[0]) == DataOperation.Receive)
             {
-                if (((DataOperation)value) == DataOperation.Receive)
+                if (values[1] is Style)
                 {
-                    return new SolidColorBrush(Colors.LightGray);                    
-                }                                
+                    return NormalDarkMode;
+                }
+
+                return new SolidColorBrush(Colors.LightGray);
+            }
+
+            if (values[1] is Style)
+            {
+                return LightDarkMode;
             }
 
             return new SolidColorBrush(Colors.White);
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, System.Globalization.CultureInfo culture)
         {
             throw new NotImplementedException();
         }

--- a/src/Lime.Client.TestConsole/Converters/DataOperationToBrushConverter.cs
+++ b/src/Lime.Client.TestConsole/Converters/DataOperationToBrushConverter.cs
@@ -25,7 +25,7 @@ namespace Lime.Client.TestConsole.Converters
 
             if (direction is DataOperation && ((DataOperation)direction) == DataOperation.Receive)
             {
-                if (values[1] is Style)
+                if (darkMode is Style)
                 {
                     return NormalDarkMode;
                 }

--- a/src/Lime.Client.TestConsole/Converters/DataOperationToBrushConverter.cs
+++ b/src/Lime.Client.TestConsole/Converters/DataOperationToBrushConverter.cs
@@ -13,8 +13,8 @@ namespace Lime.Client.TestConsole.Converters
     public class DataOperationToBrushConverter : IMultiValueConverter
     {
 
-        private readonly SolidColorBrush LightDarkMode = (SolidColorBrush)(new BrushConverter().ConvertFrom("#1e1e1e"));
-        private readonly SolidColorBrush NormalDarkMode = (SolidColorBrush)(new BrushConverter().ConvertFrom("#252526"));
+        private readonly SolidColorBrush LightDarkMode = (SolidColorBrush)(new BrushConverter().ConvertFrom("#424242"));
+        private readonly SolidColorBrush NormalDarkMode = (SolidColorBrush)(new BrushConverter().ConvertFrom("#212121"));
 
         #region IValueConverter Members
 

--- a/src/Lime.Client.TestConsole/Converters/DataOperationToBrushConverter.cs
+++ b/src/Lime.Client.TestConsole/Converters/DataOperationToBrushConverter.cs
@@ -20,10 +20,10 @@ namespace Lime.Client.TestConsole.Converters
 
         public object Convert(object[] values, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            //First value is Direction property
-            //Second value is IsDarkMode property
+            var direction = values[0];
+            var darkMode = values[1];
 
-            if (values[0] is DataOperation && ((DataOperation)values[0]) == DataOperation.Receive)
+            if (direction is DataOperation && ((DataOperation)direction) == DataOperation.Receive)
             {
                 if (values[1] is Style)
                 {
@@ -33,7 +33,7 @@ namespace Lime.Client.TestConsole.Converters
                 return new SolidColorBrush(Colors.LightGray);
             }
 
-            if (values[1] is Style)
+            if (darkMode is Style)
             {
                 return LightDarkMode;
             }

--- a/src/Lime.Client.TestConsole/Converters/IsErrorToBrushConverter.cs
+++ b/src/Lime.Client.TestConsole/Converters/IsErrorToBrushConverter.cs
@@ -4,27 +4,36 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Data;
 using System.Windows.Media;
 
 namespace Lime.Client.TestConsole.Converters
 {
-    public class IsErrorToBrushConverter : IValueConverter
+    public class IsErrorToBrushConverter : IMultiValueConverter
     {
         #region IValueConverter Members
 
-        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        public object Convert(object[] values, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            if (value is bool &&
-                ((bool)value))
+            //First value is IsErrror property
+            //Second value is IsDarkMode property
+
+            if (values[0] is bool &&
+                (bool)values[0])
             {
                 return new SolidColorBrush(Colors.Red);
+            }
+
+            if (values[1] is Style)
+            {
+                return new SolidColorBrush(Colors.White);
             }
 
             return new SolidColorBrush(Colors.Black);
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        public object[] ConvertBack(object value, Type[] targetType, object parameter, System.Globalization.CultureInfo culture)
         {
             throw new NotImplementedException();
         }

--- a/src/Lime.Client.TestConsole/Converters/IsErrorToBrushConverter.cs
+++ b/src/Lime.Client.TestConsole/Converters/IsErrorToBrushConverter.cs
@@ -16,16 +16,16 @@ namespace Lime.Client.TestConsole.Converters
 
         public object Convert(object[] values, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            //First value is IsErrror property
-            //Second value is IsDarkMode property
+            var isError = values[0];
+            var darkMode = values[1];
 
-            if (values[0] is bool &&
-                (bool)values[0])
+            if (isError is bool &&
+                (bool)isError)
             {
                 return new SolidColorBrush(Colors.Red);
             }
 
-            if (values[1] is Style)
+            if (darkMode is Style)
             {
                 return new SolidColorBrush(Colors.White);
             }

--- a/src/Lime.Client.TestConsole/Converters/IsErrorToBrushConverter.cs
+++ b/src/Lime.Client.TestConsole/Converters/IsErrorToBrushConverter.cs
@@ -33,7 +33,7 @@ namespace Lime.Client.TestConsole.Converters
             return new SolidColorBrush(Colors.Black);
         }
 
-        public object[] ConvertBack(object value, Type[] targetType, object parameter, System.Globalization.CultureInfo culture)
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, System.Globalization.CultureInfo culture)
         {
             throw new NotImplementedException();
         }

--- a/src/Lime.Client.TestConsole/Converters/IsRawToBrushConverter.cs
+++ b/src/Lime.Client.TestConsole/Converters/IsRawToBrushConverter.cs
@@ -4,29 +4,35 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Data;
 using System.Windows.Media;
 
 namespace Lime.Client.TestConsole.Converters
 {
-    public class IsRawToBrushConverter : IValueConverter
+    public class IsRawToBrushConverter : IMultiValueConverter
     {
         #region IValueConverter Members
 
-        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        public object Convert(object[] values, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            if (value is bool)
+            //First value is IsRaw property
+            //Second value is IsDarkMode property
+
+            if (values[0] is bool && (bool)values[0])
             {
-                if ((bool)value)
-                {
-                    return new SolidColorBrush(Colors.Red);
-                }                                
+                return new SolidColorBrush(Colors.Red);
+            }
+
+            if (values[1] is Style)
+            {
+                return new SolidColorBrush(Colors.White);
             }
 
             return new SolidColorBrush(Colors.Black);
         }
 
-        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, System.Globalization.CultureInfo culture)
         {
             throw new NotImplementedException();
         }

--- a/src/Lime.Client.TestConsole/Converters/IsRawToBrushConverter.cs
+++ b/src/Lime.Client.TestConsole/Converters/IsRawToBrushConverter.cs
@@ -16,15 +16,15 @@ namespace Lime.Client.TestConsole.Converters
 
         public object Convert(object[] values, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            //First value is IsRaw property
-            //Second value is IsDarkMode property
+            var isRaw = values[0];
+            var darkMode = values[1];
 
-            if (values[0] is bool && (bool)values[0])
+            if (isRaw is bool && (bool)isRaw)
             {
                 return new SolidColorBrush(Colors.Red);
             }
 
-            if (values[1] is Style)
+            if (darkMode is Style)
             {
                 return new SolidColorBrush(Colors.White);
             }

--- a/src/Lime.Client.TestConsole/Lime.Client.TestConsole.csproj
+++ b/src/Lime.Client.TestConsole/Lime.Client.TestConsole.csproj
@@ -246,6 +246,10 @@
       <DependentUpon>MainWindow.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Page Include="Views\DarkModeDictionary.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Views\EnvelopeView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/src/Lime.Client.TestConsole/Macros/NotifyMessageConsumedMacro.cs
+++ b/src/Lime.Client.TestConsole/Macros/NotifyMessageConsumedMacro.cs
@@ -41,12 +41,10 @@ namespace Lime.Client.TestConsole.Macros
                 {
                     Envelope = notification
                 };
-
-                sessionViewModel.InputJson = notificationEnvelopeViewModel.Json;
                 
                 if (sessionViewModel.SendCommand.CanExecute(null))
                 {
-                    await sessionViewModel.SendCommand.ExecuteAsync(null);
+                    await sessionViewModel.SendCommand.ExecuteAsync(notificationEnvelopeViewModel.Json);
                 }
             }
         }

--- a/src/Lime.Client.TestConsole/Macros/NotifyMessageReceivedMacro.cs
+++ b/src/Lime.Client.TestConsole/Macros/NotifyMessageReceivedMacro.cs
@@ -35,11 +35,9 @@ namespace Lime.Client.TestConsole.Macros
                     Envelope = notification
                 };
 
-                sessionViewModel.InputJson = notificationEnvelopeViewModel.Json;
-
                 if (sessionViewModel.SendCommand.CanExecute(null))
                 {
-                    await sessionViewModel.SendCommand.ExecuteAsync(null);
+                    await sessionViewModel.SendCommand.ExecuteAsync(notificationEnvelopeViewModel.Json);
                 }
             }
         }

--- a/src/Lime.Client.TestConsole/Macros/ReplyPingMacro.cs
+++ b/src/Lime.Client.TestConsole/Macros/ReplyPingMacro.cs
@@ -46,15 +46,10 @@ namespace Lime.Client.TestConsole.Macros
                     Envelope = commandResponse
                 };
 
-                sessionViewModel.JsonToSend = commandEnvelopeViewModel.Json;
-
                 if (sessionViewModel.SendCommand.CanExecute(null))
                 {
-                    await sessionViewModel.SendCommand.ExecuteAsync(null);
+                    await sessionViewModel.SendCommand.ExecuteAsync(commandEnvelopeViewModel.Json);
                 }
-
-                sessionViewModel.JsonToSend = string.Empty;
-
             }
         }
 

--- a/src/Lime.Client.TestConsole/Macros/ReplyPingMacro.cs
+++ b/src/Lime.Client.TestConsole/Macros/ReplyPingMacro.cs
@@ -46,12 +46,15 @@ namespace Lime.Client.TestConsole.Macros
                     Envelope = commandResponse
                 };
 
-                sessionViewModel.InputJson = commandEnvelopeViewModel.Json;
+                sessionViewModel.JsonToSend = commandEnvelopeViewModel.Json;
 
                 if (sessionViewModel.SendCommand.CanExecute(null))
                 {
                     await sessionViewModel.SendCommand.ExecuteAsync(null);
                 }
+
+                sessionViewModel.JsonToSend = string.Empty;
+
             }
         }
 

--- a/src/Lime.Client.TestConsole/Macros/SendTemplateMacroBase.cs
+++ b/src/Lime.Client.TestConsole/Macros/SendTemplateMacroBase.cs
@@ -17,10 +17,9 @@ namespace Lime.Client.TestConsole.Macros
                 var template = sessionViewModel.Templates.FirstOrDefault(t => t.Name.Equals(TemplateName, StringComparison.OrdinalIgnoreCase));
                 if (template != null)
                 {
-                    sessionViewModel.InputJson = template.JsonTemplate;
                     if (sessionViewModel.SendCommand.CanExecute(null))
                     {
-                        await sessionViewModel.SendCommand.ExecuteAsync(null);
+                        await sessionViewModel.SendCommand.ExecuteAsync(template.JsonTemplate);
                     }
                 }
             }            

--- a/src/Lime.Client.TestConsole/MainWindow.xaml
+++ b/src/Lime.Client.TestConsole/MainWindow.xaml
@@ -12,9 +12,11 @@
         Title="{Binding Title}" Height="600" Width="800" Icon="lime.ico">
 
     <Window.Resources>
+        <SolidColorBrush x:Key="DarkModeColor">#2D2D2D</SolidColorBrush>
+        
         <Style x:Key="darkMode" TargetType="Control">
             <Setter Property="Foreground" Value="White"></Setter>
-            <Setter Property="Background" Value="DarkSlateGray"></Setter>
+            <Setter Property="Background" Value="{DynamicResource DarkModeColor}"></Setter>
             <Style.Resources>
                 <Style TargetType="Label">
                     <Setter Property="Foreground" Value="White"></Setter>
@@ -47,9 +49,15 @@
                 </Style>
                 <Style TargetType="DataGridRow">
                     <Setter Property="Foreground" Value="White"></Setter>
-                    <Setter Property="Background" Value="DarkSlateGray"></Setter>
+                    <Setter Property="Background" Value="{DynamicResource DarkModeColor}"></Setter>
                 </Style>
                 <Style TargetType="StackPanel">
+                    <Setter Property="Background" Value="Transparent"></Setter>
+                </Style>
+                <Style TargetType="StatusBar">
+                    <Setter Property="Background" Value="Transparent"></Setter>
+                </Style>
+                <Style TargetType="GridSplitter">
                     <Setter Property="Background" Value="Transparent"></Setter>
                 </Style>                
             </Style.Resources>

--- a/src/Lime.Client.TestConsole/MainWindow.xaml
+++ b/src/Lime.Client.TestConsole/MainWindow.xaml
@@ -3,12 +3,45 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
         xmlns:vw="clr-namespace:Lime.Client.TestConsole.Views"
+        xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"       
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"         
         xmlns:i="clr-namespace:System.Windows.Interactivity;assembly=System.Windows.Interactivity"
         mc:Ignorable="d" 
         DataContext="{StaticResource MainViewModel}"
         d:DataContext="{d:DesignData /DesignData/MainDesignData.xaml}"   
         Title="{Binding Title}" Height="600" Width="800" Icon="lime.ico">
+
+    <Window.Resources>
+        <Style x:Key="darkMode" TargetType="Control">
+            <Setter Property="Foreground" Value="White"></Setter>
+            <Setter Property="Background" Value="DarkSlateGray"></Setter>
+            <Style.Resources>
+                <Style TargetType="Label">
+                    <Setter Property="Foreground" Value="White"></Setter>
+                </Style>
+                <Style TargetType="TextBlock">
+                    <Setter Property="Foreground" Value="White"></Setter>
+                </Style>
+                <Style TargetType="CheckBox">
+                    <Setter Property="Foreground" Value="White"></Setter>
+                </Style>
+                <Style TargetType="TextBox">
+                    <Setter Property="Foreground" Value="White"></Setter>
+                    <Setter Property="Background" Value="Transparent"></Setter>
+                </Style>
+                <Style TargetType="xctk:WatermarkTextBox">
+                    <Setter Property="Foreground" Value="White"></Setter>
+                    <Setter Property="Background" Value="Transparent"></Setter>
+                </Style>
+                <Style TargetType="ListBox">
+                    <Setter Property="Foreground" Value="White"></Setter>
+                    <Setter Property="Background" Value="Transparent"></Setter>                    
+                </Style>
+                
+            </Style.Resources>
+        </Style>
+    </Window.Resources>
+    
     <i:Interaction.Triggers>
         <i:EventTrigger EventName="Closing">
             <i:InvokeCommandAction Command="{Binding ClosingCommand}" />
@@ -17,7 +50,17 @@
             <i:InvokeCommandAction Command="{Binding ClosedCommand}" />
         </i:EventTrigger>
     </i:Interaction.Triggers>
-    
-    <vw:SessionView DataContext="{Binding SelectedSession}" />
-    
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <Menu Grid.Row="0" Height="18" Name="menu1" Width="150" Margin="10, 10, 5, 5" HorizontalAlignment="Left" VerticalAlignment="Top" Background="Transparent">
+            <MenuItem Name="IsDarkMode" Header="Utlizar Dark Mode" IsCheckable="True" Checked="IsDarkMode_Checked" Unchecked="IsDarkMode_Checked"></MenuItem>
+        </Menu>
+        <vw:SessionView x:Name="SessionView" DataContext="{Binding SelectedSession}" Grid.Row="1" />
+    </Grid>
+
 </Window>

--- a/src/Lime.Client.TestConsole/MainWindow.xaml
+++ b/src/Lime.Client.TestConsole/MainWindow.xaml
@@ -13,6 +13,7 @@
 
     <Window.Resources>
         <SolidColorBrush x:Key="DarkModeColor">#2D2D2D</SolidColorBrush>
+        <SolidColorBrush x:Key="DarkModeDataGridHeader">#18191A</SolidColorBrush>        
         
         <Style x:Key="darkMode" TargetType="Control">
             <Setter Property="Foreground" Value="White"></Setter>
@@ -65,7 +66,11 @@
                     <Setter Property="Background" Value="Transparent"></Setter>
                     <Setter Property="Margin" Value="0,0,5,0" />
                     <Setter Property="Padding" Value="15,2" />
-                </Style>                
+                </Style>
+                <Style TargetType="DataGridColumnHeader">
+                    <Setter Property="Foreground" Value="White"></Setter>
+                    <Setter Property="Background" Value="{DynamicResource DarkModeDataGridHeader}"></Setter>
+                </Style>
             </Style.Resources>
         </Style>
     </Window.Resources>
@@ -88,7 +93,7 @@
         <Menu Grid.Row="0" Height="18" Name="menu1" Width="150" Margin="10, 10, 5, 5" HorizontalAlignment="Left" VerticalAlignment="Top" Background="Transparent">
             <MenuItem Name="IsDarkMode" Header="Utlizar Dark Mode" IsCheckable="True" Checked="IsDarkMode_Checked" Unchecked="IsDarkMode_Checked"></MenuItem>
         </Menu>
-        <vw:SessionView x:Name="SessionView" DataContext="{Binding SelectedSession}" Grid.Row="1" />
+        <vw:SessionView x:Name="SessionView" Margin="10,0,5,5" DataContext="{Binding SelectedSession}" Grid.Row="1" />
     </Grid>
 
 </Window>

--- a/src/Lime.Client.TestConsole/MainWindow.xaml
+++ b/src/Lime.Client.TestConsole/MainWindow.xaml
@@ -10,71 +10,7 @@
         DataContext="{StaticResource MainViewModel}"
         d:DataContext="{d:DesignData /DesignData/MainDesignData.xaml}"   
         Title="{Binding Title}" Height="600" Width="800" Icon="lime.ico">
-
-    <Window.Resources>
-        <SolidColorBrush x:Key="DarkModeColor">#2D2D2D</SolidColorBrush>
-        <SolidColorBrush x:Key="DarkModeDataGridHeader">#18191A</SolidColorBrush>        
-        
-        <Style x:Key="darkMode" TargetType="Control">
-            <Setter Property="Foreground" Value="White"></Setter>
-            <Setter Property="Background" Value="{DynamicResource DarkModeColor}"></Setter>
-            <Style.Resources>
-                <Style TargetType="Label">
-                    <Setter Property="Foreground" Value="White"></Setter>
-                </Style>
-                <Style TargetType="TextBlock">
-                    <Setter Property="Foreground" Value="White"></Setter>
-                </Style>
-                <Style TargetType="CheckBox">
-                    <Setter Property="Foreground" Value="White"></Setter>
-                </Style>
-                <Style TargetType="TextBox">
-                    <Setter Property="Foreground" Value="White"></Setter>
-                    <Setter Property="Background" Value="Transparent"></Setter>
-                </Style>
-                <Style TargetType="xctk:WatermarkTextBox">
-                    <Setter Property="Foreground" Value="White"></Setter>
-                    <Setter Property="Background" Value="Transparent"></Setter>
-                </Style>
-                <Style TargetType="ListBox">
-                    <Setter Property="Foreground" Value="White"></Setter>
-                    <Setter Property="Background" Value="Transparent"></Setter>
-                </Style>
-                <Style TargetType="xctk:IntegerUpDown">
-                    <Setter Property="Foreground" Value="White"></Setter>
-                    <Setter Property="Background" Value="Transparent"></Setter>
-                </Style>
-                <Style TargetType="MenuItem">
-                    <Setter Property="Foreground" Value="White"></Setter>
-                    <Setter Property="Background" Value="Transparent"></Setter>
-                </Style>
-                <Style TargetType="DataGridRow">
-                    <Setter Property="Foreground" Value="White"></Setter>
-                    <Setter Property="Background" Value="{DynamicResource DarkModeColor}"></Setter>
-                </Style>
-                <Style TargetType="StackPanel">
-                    <Setter Property="Background" Value="Transparent"></Setter>
-                </Style>
-                <Style TargetType="StatusBar">
-                    <Setter Property="Background" Value="Transparent"></Setter>
-                </Style>
-                <Style TargetType="GridSplitter">
-                    <Setter Property="Background" Value="Transparent"></Setter>
-                </Style>
-                <Style TargetType="Button">
-                    <Setter Property="Foreground" Value="White"></Setter>
-                    <Setter Property="Background" Value="Transparent"></Setter>
-                    <Setter Property="Margin" Value="0,0,5,0" />
-                    <Setter Property="Padding" Value="15,2" />
-                </Style>
-                <Style TargetType="DataGridColumnHeader">
-                    <Setter Property="Foreground" Value="White"></Setter>
-                    <Setter Property="Background" Value="{DynamicResource DarkModeDataGridHeader}"></Setter>
-                </Style>
-            </Style.Resources>
-        </Style>
-    </Window.Resources>
-    
+   
     <i:Interaction.Triggers>
         <i:EventTrigger EventName="Closing">
             <i:InvokeCommandAction Command="{Binding ClosingCommand}" />
@@ -85,15 +21,7 @@
     </i:Interaction.Triggers>
 
     <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
-
-        <Menu Grid.Row="0" Height="18" Name="menu1" Width="150" Margin="10, 10, 5, 5" HorizontalAlignment="Left" VerticalAlignment="Top" Background="Transparent">
-            <MenuItem Name="IsDarkMode" Header="Utlizar Dark Mode" IsCheckable="True" Checked="IsDarkMode_Checked" Unchecked="IsDarkMode_Checked"></MenuItem>
-        </Menu>
-        <vw:SessionView x:Name="SessionView" Margin="10,0,5,5" DataContext="{Binding SelectedSession}" Grid.Row="1" />
+        <vw:SessionView x:Name="SessionView" DataContext="{Binding SelectedSession}" Grid.Row="1" />
     </Grid>
 
 </Window>

--- a/src/Lime.Client.TestConsole/MainWindow.xaml
+++ b/src/Lime.Client.TestConsole/MainWindow.xaml
@@ -35,9 +35,23 @@
                 </Style>
                 <Style TargetType="ListBox">
                     <Setter Property="Foreground" Value="White"></Setter>
-                    <Setter Property="Background" Value="Transparent"></Setter>                    
+                    <Setter Property="Background" Value="Transparent"></Setter>
                 </Style>
-                
+                <Style TargetType="xctk:IntegerUpDown">
+                    <Setter Property="Foreground" Value="White"></Setter>
+                    <Setter Property="Background" Value="Transparent"></Setter>
+                </Style>
+                <Style TargetType="MenuItem">
+                    <Setter Property="Foreground" Value="White"></Setter>
+                    <Setter Property="Background" Value="Transparent"></Setter>
+                </Style>
+                <Style TargetType="DataGridRow">
+                    <Setter Property="Foreground" Value="White"></Setter>
+                    <Setter Property="Background" Value="DarkSlateGray"></Setter>
+                </Style>
+                <Style TargetType="StackPanel">
+                    <Setter Property="Background" Value="Transparent"></Setter>
+                </Style>                
             </Style.Resources>
         </Style>
     </Window.Resources>

--- a/src/Lime.Client.TestConsole/MainWindow.xaml
+++ b/src/Lime.Client.TestConsole/MainWindow.xaml
@@ -59,6 +59,12 @@
                 </Style>
                 <Style TargetType="GridSplitter">
                     <Setter Property="Background" Value="Transparent"></Setter>
+                </Style>
+                <Style TargetType="Button">
+                    <Setter Property="Foreground" Value="White"></Setter>
+                    <Setter Property="Background" Value="Transparent"></Setter>
+                    <Setter Property="Margin" Value="0,0,5,0" />
+                    <Setter Property="Padding" Value="15,2" />
                 </Style>                
             </Style.Resources>
         </Style>

--- a/src/Lime.Client.TestConsole/MainWindow.xaml.cs
+++ b/src/Lime.Client.TestConsole/MainWindow.xaml.cs
@@ -32,10 +32,14 @@ namespace Lime.Client.TestConsole
             if (isDarkMode.IsChecked)
             {
                 SessionView.Style = (Style)Resources["darkMode"];
+                this.Style = (Style)Resources["darkMode"];
+
             }
+
             else
             {
                 SessionView.Style = null;
+                this.Style = null;
             }
         }
     }

--- a/src/Lime.Client.TestConsole/MainWindow.xaml.cs
+++ b/src/Lime.Client.TestConsole/MainWindow.xaml.cs
@@ -24,5 +24,19 @@ namespace Lime.Client.TestConsole
         {
             InitializeComponent();
         }
+
+        private void IsDarkMode_Checked(object sender, RoutedEventArgs e)
+        {
+            MenuItem isDarkMode = (MenuItem)sender;
+
+            if (isDarkMode.IsChecked)
+            {
+                SessionView.Style = (Style)Resources["darkMode"];
+            }
+            else
+            {
+                SessionView.Style = null;
+            }
+        }
     }
 }

--- a/src/Lime.Client.TestConsole/MainWindow.xaml.cs
+++ b/src/Lime.Client.TestConsole/MainWindow.xaml.cs
@@ -1,17 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+﻿using System.Windows;
 
 namespace Lime.Client.TestConsole
 {
@@ -23,24 +10,6 @@ namespace Lime.Client.TestConsole
         public MainWindow()
         {
             InitializeComponent();
-        }
-
-        private void IsDarkMode_Checked(object sender, RoutedEventArgs e)
-        {
-            MenuItem isDarkMode = (MenuItem)sender;
-
-            if (isDarkMode.IsChecked)
-            {
-                SessionView.Style = (Style)Resources["darkMode"];
-                this.Style = (Style)Resources["darkMode"];
-
-            }
-
-            else
-            {
-                SessionView.Style = null;
-                this.Style = null;
-            }
         }
     }
 }

--- a/src/Lime.Client.TestConsole/Properties/AssemblyInfo.cs
+++ b/src/Lime.Client.TestConsole/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("0.10.0.0")]
+[assembly: AssemblyFileVersion("0.10.0.0")]

--- a/src/Lime.Client.TestConsole/Properties/AssemblyInfo.cs
+++ b/src/Lime.Client.TestConsole/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.7.0.0")]
-[assembly: AssemblyFileVersion("0.7.0.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Lime.Client.TestConsole/ViewModels/SessionViewModel.cs
+++ b/src/Lime.Client.TestConsole/ViewModels/SessionViewModel.cs
@@ -733,7 +733,7 @@ namespace Lime.Client.TestConsole.ViewModels
 
         public AsyncCommand SendCommand { get; private set; }
 
-        private async Task SendAsync()
+        private async Task SendAsync(object parameter)
         {
             var times = 0;
 
@@ -755,7 +755,7 @@ namespace Lime.Client.TestConsole.ViewModels
                 {
                     AddStatusMessage("Sending...");
 
-                    var inputJson = !string.IsNullOrWhiteSpace(JsonToSend) ? JsonToSend : InputJson;
+                    var inputJson = parameter.ToString();
 
                     if (ParseBeforeSend)
                     {

--- a/src/Lime.Client.TestConsole/ViewModels/SessionViewModel.cs
+++ b/src/Lime.Client.TestConsole/ViewModels/SessionViewModel.cs
@@ -755,7 +755,7 @@ namespace Lime.Client.TestConsole.ViewModels
                 {
                     AddStatusMessage("Sending...");
 
-                    var inputJson = !string.IsNullOrEmpty(JsonToSend) ? JsonToSend : InputJson;
+                    var inputJson = !string.IsNullOrWhiteSpace(JsonToSend) ? JsonToSend : InputJson;
 
                     if (ParseBeforeSend)
                     {

--- a/src/Lime.Client.TestConsole/ViewModels/SessionViewModel.cs
+++ b/src/Lime.Client.TestConsole/ViewModels/SessionViewModel.cs
@@ -225,6 +225,8 @@ namespace Lime.Client.TestConsole.ViewModels
             }
         }
 
+        public string JsonToSend { get; set; }
+
         private string _host;
 
         private Uri _hostUri;
@@ -753,11 +755,11 @@ namespace Lime.Client.TestConsole.ViewModels
                 {
                     AddStatusMessage("Sending...");
 
-                    var inputJson = InputJson;
+                    var inputJson = !string.IsNullOrEmpty(JsonToSend) ? JsonToSend : InputJson;
 
                     if (ParseBeforeSend)
                     {
-                        inputJson = ParseInput(InputJson, Variables);
+                        inputJson = ParseInput(inputJson, Variables);
                     }
 
                     var timeoutCancellationToken = _operationTimeout.ToCancellationToken();

--- a/src/Lime.Client.TestConsole/Views/DarkModeDictionary.xaml
+++ b/src/Lime.Client.TestConsole/Views/DarkModeDictionary.xaml
@@ -1,0 +1,75 @@
+﻿<ResourceDictionary 
+xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:vw="clr-namespace:Lime.Client.TestConsole.Views"
+             xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
+             xmlns:xcad="http://schemas.xceed.com/wpf/xaml/avalondock"
+             mc:Ignorable="d"
+             xmlns:i="clr-namespace:System.Windows.Interactivity;assembly=System.Windows.Interactivity" >
+
+    <SolidColorBrush x:Key="DarkModeColor">#2D2D2D</SolidColorBrush>
+    <SolidColorBrush x:Key="DarkModeDataGridHeader">#18191A</SolidColorBrush>
+
+    <Style x:Key="darkMode" TargetType="Control">
+        <Setter Property="Foreground" Value="White"></Setter>
+        <Setter Property="Background" Value="{DynamicResource DarkModeColor}"></Setter>
+        <Style.Resources>
+            <Style TargetType="Label">
+                <Setter Property="Foreground" Value="White"></Setter>
+            </Style>
+            <Style TargetType="TextBlock">
+                <Setter Property="Foreground" Value="White"></Setter>
+            </Style>
+            <Style TargetType="CheckBox">
+                <Setter Property="Foreground" Value="White"></Setter>
+            </Style>
+            <Style TargetType="TextBox">
+                <Setter Property="Foreground" Value="White"></Setter>
+                <Setter Property="CaretBrush" Value="White"></Setter>
+                <Setter Property="Background" Value="Transparent"></Setter>
+            </Style>
+            <Style TargetType="xctk:WatermarkTextBox">
+                <Setter Property="Foreground" Value="White"></Setter>
+                <Setter Property="CaretBrush" Value="White"></Setter>
+                <Setter Property="Background" Value="Transparent"></Setter>
+            </Style>
+            <Style TargetType="ListBox">
+                <Setter Property="Foreground" Value="White"></Setter>
+                <Setter Property="Background" Value="Transparent"></Setter>
+            </Style>
+            <Style TargetType="xctk:IntegerUpDown">
+                <Setter Property="Foreground" Value="White"></Setter>
+                <Setter Property="Background" Value="Transparent"></Setter>
+            </Style>
+            <Style TargetType="MenuItem">
+                <Setter Property="Foreground" Value="White"></Setter>
+                <Setter Property="Background" Value="Transparent"></Setter>
+            </Style>
+            <Style TargetType="DataGridRow">
+                <Setter Property="Foreground" Value="White"></Setter>
+                <Setter Property="Background" Value="{DynamicResource DarkModeColor}"></Setter>
+            </Style>
+            <Style TargetType="StackPanel">
+                <Setter Property="Background" Value="Transparent"></Setter>
+            </Style>
+            <Style TargetType="StatusBar">
+                <Setter Property="Background" Value="Transparent"></Setter>
+            </Style>
+            <Style TargetType="GridSplitter">
+                <Setter Property="Background" Value="Transparent"></Setter>
+            </Style>
+            <Style TargetType="Button">
+                <Setter Property="Foreground" Value="White"></Setter>
+                <Setter Property="Background" Value="Transparent"></Setter>
+                <Setter Property="Margin" Value="0,0,5,0" />
+                <Setter Property="Padding" Value="15,2" />
+            </Style>
+            <Style TargetType="DataGridColumnHeader">
+                <Setter Property="Foreground" Value="White"></Setter>
+                <Setter Property="Background" Value="{DynamicResource DarkModeDataGridHeader}"></Setter>
+            </Style>
+        </Style.Resources>
+    </Style>
+</ResourceDictionary>

--- a/src/Lime.Client.TestConsole/Views/EnvelopeView.xaml
+++ b/src/Lime.Client.TestConsole/Views/EnvelopeView.xaml
@@ -8,10 +8,6 @@
              d:DesignHeight="200" d:DesignWidth="500"
              Name="UcEnvelopesView">
     
-    <!--<TextBox Background="{Binding Direction, Converter={StaticResource DataOperationToBrushConverter}}" 
-             Foreground="{Binding IsRaw, Converter={StaticResource IsRawToBrushConverter}}"
-             Text="{Binding Json}" 
-             Style="{StaticResource ReadOnlyTextBox}" />-->
     <TextBox Text="{Binding Json}" Style="{StaticResource ReadOnlyTextBox}">
         <TextBox.Background>
             <MultiBinding Converter="{StaticResource DataOperationToBrushConverter}">

--- a/src/Lime.Client.TestConsole/Views/EnvelopeView.xaml
+++ b/src/Lime.Client.TestConsole/Views/EnvelopeView.xaml
@@ -5,9 +5,25 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              mc:Ignorable="d" 
              d:DataContext="{d:DesignData /DesignData/EnvelopeDesignData.xaml}"                
-             d:DesignHeight="200" d:DesignWidth="500">
-    <TextBox Background="{Binding Direction, Converter={StaticResource DataOperationToBrushConverter}}" 
+             d:DesignHeight="200" d:DesignWidth="500"
+             Name="UcEnvelopesView">
+    
+    <!--<TextBox Background="{Binding Direction, Converter={StaticResource DataOperationToBrushConverter}}" 
              Foreground="{Binding IsRaw, Converter={StaticResource IsRawToBrushConverter}}"
              Text="{Binding Json}" 
-             Style="{StaticResource ReadOnlyTextBox}" />    
+             Style="{StaticResource ReadOnlyTextBox}" />-->
+    <TextBox Text="{Binding Json}" Style="{StaticResource ReadOnlyTextBox}">
+        <TextBox.Background>
+            <MultiBinding Converter="{StaticResource DataOperationToBrushConverter}">
+                <Binding Path="Direction"></Binding>
+                <Binding ElementName="EnvelopesListBox" Path="Style"></Binding>
+            </MultiBinding>
+        </TextBox.Background>
+        <TextBox.Foreground>
+            <MultiBinding Converter="{StaticResource IsRawToBrushConverter}">
+                <Binding Path="IsRaw"></Binding>
+                <Binding ElementName="EnvelopesListBox" Path="Style"></Binding>
+            </MultiBinding>            
+        </TextBox.Foreground>
+    </TextBox>
 </UserControl>

--- a/src/Lime.Client.TestConsole/Views/SessionView.xaml
+++ b/src/Lime.Client.TestConsole/Views/SessionView.xaml
@@ -14,69 +14,7 @@
              Name="UcSessionView">
 
     <UserControl.Resources>
-        <SolidColorBrush x:Key="DarkModeColor">#2D2D2D</SolidColorBrush>
-        <SolidColorBrush x:Key="DarkModeDataGridHeader">#18191A</SolidColorBrush>
-
-        <Style x:Key="darkMode" TargetType="Control">
-            <Setter Property="Foreground" Value="White"></Setter>
-            <Setter Property="Background" Value="{DynamicResource DarkModeColor}"></Setter>
-            <Style.Resources>
-                <Style TargetType="Label">
-                    <Setter Property="Foreground" Value="White"></Setter>
-                </Style>
-                <Style TargetType="TextBlock">
-                    <Setter Property="Foreground" Value="White"></Setter>
-                </Style>
-                <Style TargetType="CheckBox">
-                    <Setter Property="Foreground" Value="White"></Setter>
-                </Style>
-                <Style TargetType="TextBox">
-                    <Setter Property="Foreground" Value="White"></Setter>
-                    <Setter Property="CaretBrush" Value="White"></Setter>
-                    <Setter Property="Background" Value="Transparent"></Setter>
-                </Style>
-                <Style TargetType="xctk:WatermarkTextBox">
-                    <Setter Property="Foreground" Value="White"></Setter>
-                    <Setter Property="CaretBrush" Value="White"></Setter>
-                    <Setter Property="Background" Value="Transparent"></Setter>
-                </Style>
-                <Style TargetType="ListBox">
-                    <Setter Property="Foreground" Value="White"></Setter>
-                    <Setter Property="Background" Value="Transparent"></Setter>
-                </Style>
-                <Style TargetType="xctk:IntegerUpDown">
-                    <Setter Property="Foreground" Value="White"></Setter>
-                    <Setter Property="Background" Value="Transparent"></Setter>
-                </Style>
-                <Style TargetType="MenuItem">
-                    <Setter Property="Foreground" Value="White"></Setter>
-                    <Setter Property="Background" Value="Transparent"></Setter>
-                </Style>
-                <Style TargetType="DataGridRow">
-                    <Setter Property="Foreground" Value="White"></Setter>
-                    <Setter Property="Background" Value="{DynamicResource DarkModeColor}"></Setter>
-                </Style>
-                <Style TargetType="StackPanel">
-                    <Setter Property="Background" Value="Transparent"></Setter>
-                </Style>
-                <Style TargetType="StatusBar">
-                    <Setter Property="Background" Value="Transparent"></Setter>
-                </Style>
-                <Style TargetType="GridSplitter">
-                    <Setter Property="Background" Value="Transparent"></Setter>
-                </Style>
-                <Style TargetType="Button">
-                    <Setter Property="Foreground" Value="White"></Setter>
-                    <Setter Property="Background" Value="Transparent"></Setter>
-                    <Setter Property="Margin" Value="0,0,5,0" />
-                    <Setter Property="Padding" Value="15,2" />
-                </Style>
-                <Style TargetType="DataGridColumnHeader">
-                    <Setter Property="Foreground" Value="White"></Setter>
-                    <Setter Property="Background" Value="{DynamicResource DarkModeDataGridHeader}"></Setter>
-                </Style>
-            </Style.Resources>
-        </Style>
+        <ResourceDictionary Source="DarkModeDictionary.xaml" />
     </UserControl.Resources>
 
     <Grid>

--- a/src/Lime.Client.TestConsole/Views/SessionView.xaml
+++ b/src/Lime.Client.TestConsole/Views/SessionView.xaml
@@ -133,8 +133,8 @@
                     <ListBox.ItemTemplate>
                         <DataTemplate>
                             <StackPanel Orientation="Horizontal">
-                                <TextBox Style="{StaticResource ReadOnlyTextBox}" Text="{Binding TimestampFormat, Mode=OneWay}" />
-                                <TextBox Style="{StaticResource ReadOnlyTextBox}" Margin="5,0,0,0" Text="{Binding Message}" Foreground="{Binding IsError, Converter={StaticResource IsErrorToBrushConverter}}" />
+                                <TextBlock Text="{Binding TimestampFormat, Mode=OneWay}"></TextBlock>
+                                <TextBlock Margin="5,0,0,0" Text="{Binding Message}" Foreground="{Binding IsError, Converter={StaticResource IsErrorToBrushConverter}}"></TextBlock>
                             </StackPanel>
                         </DataTemplate>
                     </ListBox.ItemTemplate>

--- a/src/Lime.Client.TestConsole/Views/SessionView.xaml
+++ b/src/Lime.Client.TestConsole/Views/SessionView.xaml
@@ -12,99 +12,172 @@
              d:DesignHeight="768"
              d:DesignWidth="1224"
              Name="UcSessionView">
+
+    <UserControl.Resources>
+        <SolidColorBrush x:Key="DarkModeColor">#2D2D2D</SolidColorBrush>
+        <SolidColorBrush x:Key="DarkModeDataGridHeader">#18191A</SolidColorBrush>
+
+        <Style x:Key="darkMode" TargetType="Control">
+            <Setter Property="Foreground" Value="White"></Setter>
+            <Setter Property="Background" Value="{DynamicResource DarkModeColor}"></Setter>
+            <Style.Resources>
+                <Style TargetType="Label">
+                    <Setter Property="Foreground" Value="White"></Setter>
+                </Style>
+                <Style TargetType="TextBlock">
+                    <Setter Property="Foreground" Value="White"></Setter>
+                </Style>
+                <Style TargetType="CheckBox">
+                    <Setter Property="Foreground" Value="White"></Setter>
+                </Style>
+                <Style TargetType="TextBox">
+                    <Setter Property="Foreground" Value="White"></Setter>
+                    <Setter Property="Background" Value="Transparent"></Setter>
+                </Style>
+                <Style TargetType="xctk:WatermarkTextBox">
+                    <Setter Property="Foreground" Value="White"></Setter>
+                    <Setter Property="Background" Value="Transparent"></Setter>
+                </Style>
+                <Style TargetType="ListBox">
+                    <Setter Property="Foreground" Value="White"></Setter>
+                    <Setter Property="Background" Value="Transparent"></Setter>
+                </Style>
+                <Style TargetType="xctk:IntegerUpDown">
+                    <Setter Property="Foreground" Value="White"></Setter>
+                    <Setter Property="Background" Value="Transparent"></Setter>
+                </Style>
+                <Style TargetType="MenuItem">
+                    <Setter Property="Foreground" Value="White"></Setter>
+                    <Setter Property="Background" Value="Transparent"></Setter>
+                </Style>
+                <Style TargetType="DataGridRow">
+                    <Setter Property="Foreground" Value="White"></Setter>
+                    <Setter Property="Background" Value="{DynamicResource DarkModeColor}"></Setter>
+                </Style>
+                <Style TargetType="StackPanel">
+                    <Setter Property="Background" Value="Transparent"></Setter>
+                </Style>
+                <Style TargetType="StatusBar">
+                    <Setter Property="Background" Value="Transparent"></Setter>
+                </Style>
+                <Style TargetType="GridSplitter">
+                    <Setter Property="Background" Value="Transparent"></Setter>
+                </Style>
+                <Style TargetType="Button">
+                    <Setter Property="Foreground" Value="White"></Setter>
+                    <Setter Property="Background" Value="Transparent"></Setter>
+                    <Setter Property="Margin" Value="0,0,5,0" />
+                    <Setter Property="Padding" Value="15,2" />
+                </Style>
+                <Style TargetType="DataGridColumnHeader">
+                    <Setter Property="Foreground" Value="White"></Setter>
+                    <Setter Property="Background" Value="{DynamicResource DarkModeDataGridHeader}"></Setter>
+                </Style>
+            </Style.Resources>
+        </Style>
+    </UserControl.Resources>
+
     <Grid>
         <Grid.RowDefinitions>
-            <RowDefinition Height="300*" />
-            <RowDefinition Height="25" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-
-        <Grid Margin="10">
+        <Menu Grid.Row="0" Height="18" Name="menu1" Width="150" Margin="10, 10, 5, 5" HorizontalAlignment="Left" VerticalAlignment="Top" Background="Transparent">
+            <MenuItem Name="IsDarkMode" Header="Utlizar Dark Mode" IsCheckable="True" Checked="IsDarkMode_Checked" Unchecked="IsDarkMode_Checked"></MenuItem>
+        </Menu>
+        <Grid Grid.Row="1">
             <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
                 <RowDefinition Height="300*" />
-                <RowDefinition Height="5" />
-                <RowDefinition Height="150*" />
-                <RowDefinition Height="5" />
-                <RowDefinition Height="100" />
+                <RowDefinition Height="25" />
             </Grid.RowDefinitions>
 
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="200*" />
-                <ColumnDefinition Width="5" />
-                <ColumnDefinition Width="100*" />
-            </Grid.ColumnDefinitions>
-
-            <Grid Grid.Row="0" Margin="0,0,0,5">
+            <Grid Margin="10">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="300*" />
+                    <RowDefinition Height="5" />
+                    <RowDefinition Height="150*" />
+                    <RowDefinition Height="5" />
+                    <RowDefinition Height="100" />
                 </Grid.RowDefinitions>
+
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="200*" />
+                    <ColumnDefinition Width="5" />
+                    <ColumnDefinition Width="100*" />
                 </Grid.ColumnDefinitions>
 
-                <Label Grid.Row="0" Content="Host" />
-                <TextBox Grid.Row="0" Grid.Column="1" VerticalAlignment="Center" Text="{Binding Host, UpdateSourceTrigger=PropertyChanged}" Grid.ColumnSpan="2" />
+                <Grid Grid.Row="0" Margin="0,0,0,5">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
 
-                <StackPanel Grid.Row="1" Grid.Column="0"  Margin="0,5" Orientation="Horizontal" Grid.ColumnSpan="2">
-                    <Button Content="_Open" Command="{Binding OpenTransportCommand}" />
-                    <Button Content="_Close" Command="{Binding CloseTransportCommand}" />
-                    <xctk:WatermarkTextBox Margin="0,0,5,0"  VerticalAlignment="Center" Watermark="Client certificate thumbprint" Width="180" Text="{Binding ClientCertificateThumbprint, UpdateSourceTrigger=PropertyChanged}" />
-                </StackPanel>
+                    <Label Grid.Row="0" Content="Host" />
+                    <TextBox Grid.Row="0" Grid.Column="1" VerticalAlignment="Center" Text="{Binding Host, UpdateSourceTrigger=PropertyChanged}" Grid.ColumnSpan="2" />
 
-                <StackPanel Grid.Row="2" Grid.Column="0"  Margin="0,5" Orientation="Horizontal" Grid.ColumnSpan="2">
-                    <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="Last session state" />
-                    <TextBox Margin="0,0,5,0" VerticalAlignment="Center" Width="80" IsReadOnly="True" Text="{Binding LastSessionState}" />
-                    <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="Last notification" />
-                    <TextBox Margin="0,0,5,0" VerticalAlignment="Center" Width="80" IsReadOnly="True" Text="{Binding LastNotificationEvent}" />
-                </StackPanel>
+                    <StackPanel Grid.Row="1" Grid.Column="0"  Margin="0,5" Orientation="Horizontal" Grid.ColumnSpan="2">
+                        <Button Content="_Open" Command="{Binding OpenTransportCommand}" />
+                        <Button Content="_Close" Command="{Binding CloseTransportCommand}" />
+                        <xctk:WatermarkTextBox Margin="0,0,5,0"  VerticalAlignment="Center" Watermark="Client certificate thumbprint" Width="180" Text="{Binding ClientCertificateThumbprint, UpdateSourceTrigger=PropertyChanged}" />
+                    </StackPanel>
 
-                <StackPanel Grid.Row="3" Grid.Column="0"  Margin="0,5" Orientation="Horizontal" Grid.ColumnSpan="2">
-                    <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="Local node" />
-                    <TextBox Margin="0,0,5,0" VerticalAlignment="Center" Width="250" IsReadOnly="True" Text="{Binding LocalNode, Converter={StaticResource ToStringConverter}}" />
-                    <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="Remote node" />
-                    <TextBox Margin="0,0,5,0" VerticalAlignment="Center" Width="250" IsReadOnly="True" Text="{Binding RemoteNode, Converter={StaticResource ToStringConverter}}" />
-                </StackPanel>
-            </Grid>
+                    <StackPanel Grid.Row="2" Grid.Column="0"  Margin="0,5" Orientation="Horizontal" Grid.ColumnSpan="2">
+                        <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="Last session state" />
+                        <TextBox Margin="0,0,5,0" VerticalAlignment="Center" Width="80" IsReadOnly="True" Text="{Binding LastSessionState}" />
+                        <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="Last notification" />
+                        <TextBox Margin="0,0,5,0" VerticalAlignment="Center" Width="80" IsReadOnly="True" Text="{Binding LastNotificationEvent}" />
+                    </StackPanel>
 
-            <Grid Grid.Row="1" Margin="0,5">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="*" />
-                    <RowDefinition Height="Auto" />
-                </Grid.RowDefinitions>
+                    <StackPanel Grid.Row="3" Grid.Column="0"  Margin="0,5" Orientation="Horizontal" Grid.ColumnSpan="2">
+                        <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="Local node" />
+                        <TextBox Margin="0,0,5,0" VerticalAlignment="Center" Width="250" IsReadOnly="True" Text="{Binding LocalNode, Converter={StaticResource ToStringConverter}}" />
+                        <TextBlock Margin="0,0,5,0" VerticalAlignment="Center" Text="Remote node" />
+                        <TextBox Margin="0,0,5,0" VerticalAlignment="Center" Width="250" IsReadOnly="True" Text="{Binding RemoteNode, Converter={StaticResource ToStringConverter}}" />
+                    </StackPanel>
+                </Grid>
 
-                <ScrollViewer ScrollChanged="ScrollViewer_ScrollChanged" PreviewMouseWheel="ScrollViewer_PreviewMouseWheel">
-                    <ListBox ItemsSource="{Binding EnvelopesView}">
-                        <ListBox.ItemContainerStyle>
-                            <Style TargetType="ListBoxItem">
-                                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-                            </Style>
-                        </ListBox.ItemContainerStyle>
-                        <ListBox.ItemTemplate>
-                            <DataTemplate>
-                                <vw:EnvelopeView />
-                            </DataTemplate>
-                        </ListBox.ItemTemplate>
-                    </ListBox>
-                </ScrollViewer>
-                <StackPanel Margin="0,5" Orientation="Horizontal" Grid.Row="1">
-                    <Button Content="Clear" Command="{Binding ClearTraceCommand}" />
-                    <CheckBox Margin="0,5" Content="Show raw values" IsChecked="{Binding ShowRawValues}" />
-                </StackPanel>
-            </Grid>
+                <Grid Grid.Row="1" Margin="0,5">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="*" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
 
-            <GridSplitter Grid.Row="2" Height="5" HorizontalAlignment="Stretch" />
+                    <ScrollViewer ScrollChanged="ScrollViewer_ScrollChanged" PreviewMouseWheel="ScrollViewer_PreviewMouseWheel">
+                        <ListBox Name="EnvelopesListBox" ItemsSource="{Binding EnvelopesView}">
+                            <ListBox.ItemContainerStyle>
+                                <Style TargetType="ListBoxItem">
+                                    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                                </Style>
+                            </ListBox.ItemContainerStyle>
+                            <ListBox.ItemTemplate>
+                                <DataTemplate>
+                                    <vw:EnvelopeView x:Name="EnvelopesView" />
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                    </ScrollViewer>
+                    <StackPanel Margin="0,5" Orientation="Horizontal" Grid.Row="1">
+                        <Button Content="Clear" Command="{Binding ClearTraceCommand}" />
+                        <CheckBox Margin="0,5" Content="Show raw values" IsChecked="{Binding ShowRawValues}" />
+                    </StackPanel>
+                </Grid>
 
-            <Grid Grid.Row="3" Margin="0,5">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="*" />
-                    <RowDefinition Height="Auto" />
-                </Grid.RowDefinitions>
+                <GridSplitter Grid.Row="2" Height="5" HorizontalAlignment="Stretch" />
 
-                <xctk:WatermarkTextBox FontFamily="Courier New"
+                <Grid Grid.Row="3" Margin="0,5">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="*" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+
+                    <xctk:WatermarkTextBox FontFamily="Courier New"
                                        Watermark="JSON input"
                                        TextWrapping="NoWrap"
                                        VerticalScrollBarVisibility="Visible"
@@ -112,153 +185,154 @@
                                        AcceptsReturn="True"
                                        AcceptsTab="True"
                                        Text="{Binding InputJson, UpdateSourceTrigger=PropertyChanged}" />
-                <StackPanel Grid.Row="1" Margin="0,5" Orientation="Horizontal">
-                    <Button Content="_Indent" ToolTip="Indent the JSON input" Command="{Binding IndentCommand}" />
-                    <Button Content="_Validate" ToolTip="Validates the JSON input" Command="{Binding ValidateCommand}" />
-                    <Button Content="_Parse" ToolTip="Parse the input variables" Command="{Binding ParseCommand}" />
-                    <Button Content="_Send" ToolTip="Sends the JSON through the transport" Command="{Binding SendCommand}" />
-                    <CheckBox Margin="0,0,5,0" VerticalAlignment="Center" Content="Parse before send" IsChecked="{Binding ParseBeforeSend}" />
-                    <CheckBox Margin="0,0,5,0" VerticalAlignment="Center" Content="Clear after sent" IsChecked="{Binding ClearAfterSent}" />
-                    <CheckBox Margin="0,0,5,0" VerticalAlignment="Center" Content="Send as raw" IsChecked="{Binding SendAsRaw}" IsEnabled="{Binding CanSendAsRaw}" />
-                    <CheckBox Margin="0,0,5,0" VerticalAlignment="Center" Content="Ignore parsing errors" IsChecked="{Binding IgnoreParsingErrors}" />
-                    <CheckBox Margin="0,0,5,0" VerticalAlignment="Center" Content="Repeat" IsChecked="{Binding Repeat}" />
-                    <xctk:IntegerUpDown Margin="0,0,3,0" VerticalAlignment="Center" Minimum="1" Value="{Binding RepeatTimes}" />
-                    <Label Margin="0,0,3,0" Content="times" />
-                </StackPanel>
-            </Grid>
+                    <StackPanel Grid.Row="1" Margin="0,5" Orientation="Horizontal">
+                        <Button Content="_Indent" ToolTip="Indent the JSON input" Command="{Binding IndentCommand}" />
+                        <Button Content="_Validate" ToolTip="Validates the JSON input" Command="{Binding ValidateCommand}" />
+                        <Button Content="_Parse" ToolTip="Parse the input variables" Command="{Binding ParseCommand}" />
+                        <Button Content="_Send" ToolTip="Sends the JSON through the transport" Command="{Binding SendCommand}" />
+                        <CheckBox Margin="0,0,5,0" VerticalAlignment="Center" Content="Parse before send" IsChecked="{Binding ParseBeforeSend}" />
+                        <CheckBox Margin="0,0,5,0" VerticalAlignment="Center" Content="Clear after sent" IsChecked="{Binding ClearAfterSent}" />
+                        <CheckBox Margin="0,0,5,0" VerticalAlignment="Center" Content="Send as raw" IsChecked="{Binding SendAsRaw}" IsEnabled="{Binding CanSendAsRaw}" />
+                        <CheckBox Margin="0,0,5,0" VerticalAlignment="Center" Content="Ignore parsing errors" IsChecked="{Binding IgnoreParsingErrors}" />
+                        <CheckBox Margin="0,0,5,0" VerticalAlignment="Center" Content="Repeat" IsChecked="{Binding Repeat}" />
+                        <xctk:IntegerUpDown Margin="0,0,3,0" VerticalAlignment="Center" Minimum="1" Value="{Binding RepeatTimes}" />
+                        <Label Margin="0,0,3,0" Content="times" />
+                    </StackPanel>
+                </Grid>
 
-            <GridSplitter Grid.Row="4" Height="5" HorizontalAlignment="Stretch" />
+                <GridSplitter Grid.Row="4" Height="5" HorizontalAlignment="Stretch" />
 
-            <ScrollViewer Grid.Row="5" Grid.ColumnSpan="3" ScrollChanged="ScrollViewer_ScrollChanged" PreviewMouseWheel="ScrollViewer_PreviewMouseWheel">
-                <ListBox ItemsSource="{Binding StatusMessages}" SelectionMode="Extended">
-                    <ListBox.ItemTemplate>
-                        <DataTemplate>
-                            <StackPanel Orientation="Horizontal">
-                                <TextBlock Text="{Binding TimestampFormat, Mode=OneWay}"></TextBlock>
-                                <TextBlock Margin="5,0,0,0" Text="{Binding Message}">
-                                    <TextBlock.Foreground>
-                                        <MultiBinding Converter="{StaticResource IsErrorToBrushConverter }">
-                                            <Binding Path="IsError"/>
-                                            <Binding ElementName="UcSessionView" Path="Style"/>
-                                        </MultiBinding>
-                                    </TextBlock.Foreground>
-                                </TextBlock>
+                <ScrollViewer Grid.Row="5" Grid.ColumnSpan="3" ScrollChanged="ScrollViewer_ScrollChanged" PreviewMouseWheel="ScrollViewer_PreviewMouseWheel">
+                    <ListBox ItemsSource="{Binding StatusMessages}" SelectionMode="Extended">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="{Binding TimestampFormat, Mode=OneWay}"></TextBlock>
+                                    <TextBlock Margin="5,0,0,0" Text="{Binding Message}">
+                                        <TextBlock.Foreground>
+                                            <MultiBinding Converter="{StaticResource IsErrorToBrushConverter }">
+                                                <Binding Path="IsError"/>
+                                                <Binding ElementName="UcSessionView" Path="Style"/>
+                                            </MultiBinding>
+                                        </TextBlock.Foreground>
+                                    </TextBlock>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+                </ScrollViewer>
+
+                <GridSplitter Grid.Column="1" Grid.RowSpan="4" Width="5" HorizontalAlignment="Left" VerticalAlignment="Stretch" />
+
+                <Grid Grid.Row="0" Grid.RowSpan="4" Grid.Column="2">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="200*" />
+                            <RowDefinition Height="200*" />
+                            <RowDefinition Height="200*" />
+                        </Grid.RowDefinitions>
+
+                        <Grid Grid.Row="0">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*" />
+                            </Grid.RowDefinitions>
+
+                            <Label Grid.Row="0" Content="Variables" FontWeight="Bold" />
+                            <ScrollViewer Grid.Row="1" PreviewMouseWheel="ScrollViewer_PreviewMouseWheel">
+                                <DataGrid AutoGenerateColumns="False" ItemsSource="{Binding Variables}">
+                                    <DataGrid.Columns>
+                                        <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="50*" />
+                                        <DataGridTextColumn Header="Value" Binding="{Binding Value}" Width="50*" />
+                                    </DataGrid.Columns>
+                                </DataGrid>
+                            </ScrollViewer>
+                        </Grid>
+
+                        <Grid Grid.Row="1">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+
+                            <Label Grid.Row="0" Content="Templates" FontWeight="Bold" />
+                            <xctk:WatermarkTextBox Watermark="Search templates" Grid.Row="1" Text="{Binding TemplatesFilter, UpdateSourceTrigger=PropertyChanged}" />
+                            <ScrollViewer Grid.Row="2" PreviewMouseWheel="ScrollViewer_PreviewMouseWheel">
+                                <ListBox ItemsSource="{Binding TemplatesView}" SelectedValue="{Binding SelectedTemplate}">
+                                    <i:Interaction.Triggers>
+                                        <i:EventTrigger EventName="MouseDoubleClick">
+                                            <i:InvokeCommandAction Command="{Binding LoadTemplateCommand}" />
+                                        </i:EventTrigger>
+                                    </i:Interaction.Triggers>
+                                    <ListBox.ItemTemplate>
+                                        <DataTemplate>
+                                            <TextBlock Text="{Binding Name}" />
+                                        </DataTemplate>
+                                    </ListBox.ItemTemplate>
+                                    <ListBox.GroupStyle>
+                                        <GroupStyle>
+                                            <GroupStyle.HeaderTemplate>
+                                                <DataTemplate>
+                                                    <TextBlock FontWeight="Bold"  Text="{Binding Name}" />
+                                                </DataTemplate>
+                                            </GroupStyle.HeaderTemplate>
+                                        </GroupStyle>
+                                    </ListBox.GroupStyle>
+                                </ListBox>
+                            </ScrollViewer>
+                            <StackPanel Grid.Row="3" Orientation="Horizontal">
+                                <Button Content="_Load" ToolTip="Load the selected template to the input" Command="{Binding LoadTemplateCommand }" />
                             </StackPanel>
-                        </DataTemplate>
-                    </ListBox.ItemTemplate>
-                </ListBox>
-            </ScrollViewer>
+                        </Grid>
 
-            <GridSplitter Grid.Column="1" Grid.RowSpan="4" Width="5" HorizontalAlignment="Left" VerticalAlignment="Stretch" />
-
-            <Grid Grid.Row="0" Grid.RowSpan="4" Grid.Column="2">
-                <Grid>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="200*" />
-                        <RowDefinition Height="200*" />
-                        <RowDefinition Height="200*" />
-                    </Grid.RowDefinitions>
-
-                    <Grid Grid.Row="0">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="*" />
-                        </Grid.RowDefinitions>
-
-                        <Label Grid.Row="0" Content="Variables" FontWeight="Bold" />
-                        <ScrollViewer Grid.Row="1" PreviewMouseWheel="ScrollViewer_PreviewMouseWheel">
-                            <DataGrid AutoGenerateColumns="False" ItemsSource="{Binding Variables}">
-                                <DataGrid.Columns>
-                                    <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="50*" />
-                                    <DataGridTextColumn Header="Value" Binding="{Binding Value}" Width="50*" />
-                                </DataGrid.Columns>
-                            </DataGrid>
-                        </ScrollViewer>
-                    </Grid>
-
-                    <Grid Grid.Row="1">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="*" />
-                            <RowDefinition Height="Auto" />
-                        </Grid.RowDefinitions>
-
-                        <Label Grid.Row="0" Content="Templates" FontWeight="Bold" />
-                        <xctk:WatermarkTextBox Watermark="Search templates" Grid.Row="1" Text="{Binding TemplatesFilter, UpdateSourceTrigger=PropertyChanged}" />
-                        <ScrollViewer Grid.Row="2" PreviewMouseWheel="ScrollViewer_PreviewMouseWheel">
-                            <ListBox ItemsSource="{Binding TemplatesView}" SelectedValue="{Binding SelectedTemplate}">
-                                <i:Interaction.Triggers>
-                                    <i:EventTrigger EventName="MouseDoubleClick">
-                                        <i:InvokeCommandAction Command="{Binding LoadTemplateCommand}" />
-                                    </i:EventTrigger>
-                                </i:Interaction.Triggers>
-                                <ListBox.ItemTemplate>
-                                    <DataTemplate>
-                                        <TextBlock Text="{Binding Name}" />
-                                    </DataTemplate>
-                                </ListBox.ItemTemplate>
-                                <ListBox.GroupStyle>
-                                    <GroupStyle>
-                                        <GroupStyle.HeaderTemplate>
-                                            <DataTemplate>
-                                                <TextBlock FontWeight="Bold"  Text="{Binding Name}" />
-                                            </DataTemplate>
-                                        </GroupStyle.HeaderTemplate>
-                                    </GroupStyle>
-                                </ListBox.GroupStyle>
-                            </ListBox>
-                        </ScrollViewer>
-                        <StackPanel Grid.Row="3" Orientation="Horizontal">
-                            <Button Content="_Load" ToolTip="Load the selected template to the input" Command="{Binding LoadTemplateCommand }" />
-                        </StackPanel>
-                    </Grid>
-
-                    <Grid Grid.Row="2">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="*" />
-                        </Grid.RowDefinitions>
-                        <Label Grid.Row="0" Content="Macros" FontWeight="Bold" />
-                        <ScrollViewer Grid.Row="1" PreviewMouseWheel="ScrollViewer_PreviewMouseWheel">
-                            <ListBox ItemsSource="{Binding MacrosView}" SelectedValue="{Binding SelectedMacro}">
-                                <i:Interaction.Triggers>
-                                    <i:EventTrigger EventName="MouseDoubleClick">
-                                        <i:InvokeCommandAction Command="{Binding LoadTemplateCommand}" />
-                                    </i:EventTrigger>
-                                </i:Interaction.Triggers>
-                                <ListBox.ItemTemplate>
-                                    <DataTemplate>
-                                        <StackPanel Orientation="Horizontal">
-                                            <CheckBox IsChecked="{Binding IsActive, UpdateSourceTrigger=PropertyChanged}" />
-                                            <TextBlock Margin="5,0,0,0" Text="{Binding Name}" />
-                                        </StackPanel>
-                                    </DataTemplate>
-                                </ListBox.ItemTemplate>
-                                <ListBox.GroupStyle>
-                                    <GroupStyle>
-                                        <GroupStyle.HeaderTemplate>
-                                            <DataTemplate>
-                                                <TextBlock FontWeight="Bold"  Text="{Binding Name}" />
-                                            </DataTemplate>
-                                        </GroupStyle.HeaderTemplate>
-                                    </GroupStyle>
-                                </ListBox.GroupStyle>
-                            </ListBox>
-                        </ScrollViewer>
+                        <Grid Grid.Row="2">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*" />
+                            </Grid.RowDefinitions>
+                            <Label Grid.Row="0" Content="Macros" FontWeight="Bold" />
+                            <ScrollViewer Grid.Row="1" PreviewMouseWheel="ScrollViewer_PreviewMouseWheel">
+                                <ListBox ItemsSource="{Binding MacrosView}" SelectedValue="{Binding SelectedMacro}">
+                                    <i:Interaction.Triggers>
+                                        <i:EventTrigger EventName="MouseDoubleClick">
+                                            <i:InvokeCommandAction Command="{Binding LoadTemplateCommand}" />
+                                        </i:EventTrigger>
+                                    </i:Interaction.Triggers>
+                                    <ListBox.ItemTemplate>
+                                        <DataTemplate>
+                                            <StackPanel Orientation="Horizontal">
+                                                <CheckBox IsChecked="{Binding IsActive, UpdateSourceTrigger=PropertyChanged}" />
+                                                <TextBlock Margin="5,0,0,0" Text="{Binding Name}" />
+                                            </StackPanel>
+                                        </DataTemplate>
+                                    </ListBox.ItemTemplate>
+                                    <ListBox.GroupStyle>
+                                        <GroupStyle>
+                                            <GroupStyle.HeaderTemplate>
+                                                <DataTemplate>
+                                                    <TextBlock FontWeight="Bold"  Text="{Binding Name}" />
+                                                </DataTemplate>
+                                            </GroupStyle.HeaderTemplate>
+                                        </GroupStyle>
+                                    </ListBox.GroupStyle>
+                                </ListBox>
+                            </ScrollViewer>
+                        </Grid>
                     </Grid>
                 </Grid>
             </Grid>
-        </Grid>
 
-        <StatusBar Grid.Row="1">
-            <StatusBarItem>
-                <ProgressBar Width="100" Height="16" IsIndeterminate="{Binding IsBusy}" />
-            </StatusBarItem>
-            <Separator />
-            <StatusBarItem>
-                <TextBlock Text="{Binding StatusMessage}" />
-            </StatusBarItem>
-        </StatusBar>
+            <StatusBar Grid.Row="1">
+                <StatusBarItem>
+                    <ProgressBar Width="100" Height="16" IsIndeterminate="{Binding IsBusy}" />
+                </StatusBarItem>
+                <Separator />
+                <StatusBarItem>
+                    <TextBlock Text="{Binding StatusMessage}" />
+                </StatusBarItem>
+            </StatusBar>
+        </Grid>
     </Grid>
 </UserControl>

--- a/src/Lime.Client.TestConsole/Views/SessionView.xaml
+++ b/src/Lime.Client.TestConsole/Views/SessionView.xaml
@@ -135,7 +135,6 @@
                         <DataTemplate>
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock Text="{Binding TimestampFormat, Mode=OneWay}"></TextBlock>
-                                <!--<TextBlock Margin="5,0,0,0" Text="{Binding Message}" Foreground="{Binding IsError, Converter={StaticResource IsErrorToBrushConverter}}"></TextBlock>-->
                                 <TextBlock Margin="5,0,0,0" Text="{Binding Message}">
                                     <TextBlock.Foreground>
                                         <MultiBinding Converter="{StaticResource IsErrorToBrushConverter }">

--- a/src/Lime.Client.TestConsole/Views/SessionView.xaml
+++ b/src/Lime.Client.TestConsole/Views/SessionView.xaml
@@ -85,7 +85,7 @@
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
         <Menu Grid.Row="0" Height="18" Name="menu1" Width="150" Margin="10, 10, 5, 5" HorizontalAlignment="Left" VerticalAlignment="Top" Background="Transparent">
-            <MenuItem Name="IsDarkMode" Header="Utlizar Dark Mode" IsCheckable="True" Checked="IsDarkMode_Checked" Unchecked="IsDarkMode_Checked"></MenuItem>
+            <MenuItem Name="IsDarkMode" Header="Dark Mode" IsCheckable="True" Checked="IsDarkMode_Checked" Unchecked="IsDarkMode_Checked"></MenuItem>
         </Menu>
         <Grid Grid.Row="1">
             <Grid.RowDefinitions>

--- a/src/Lime.Client.TestConsole/Views/SessionView.xaml
+++ b/src/Lime.Client.TestConsole/Views/SessionView.xaml
@@ -22,9 +22,6 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <Menu Grid.Row="0" Height="18" Name="menu1" Width="150" Margin="10, 10, 5, 5" HorizontalAlignment="Left" VerticalAlignment="Top" Background="Transparent">
-            <MenuItem Name="IsDarkMode" Header="Dark Mode" IsCheckable="True" Checked="IsDarkMode_Checked" Unchecked="IsDarkMode_Checked"></MenuItem>
-        </Menu>
         <Grid Grid.Row="1">
             <Grid.RowDefinitions>
                 <RowDefinition Height="300*" />
@@ -266,12 +263,29 @@
             </Grid>
 
             <StatusBar Grid.Row="1">
+                <StatusBar.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="100" />
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="100" />
+                            </Grid.ColumnDefinitions>
+                        </Grid>
+                    </ItemsPanelTemplate>
+                </StatusBar.ItemsPanel>
                 <StatusBarItem>
-                    <ProgressBar Width="100" Height="16" IsIndeterminate="{Binding IsBusy}" />
+                    <ProgressBar Width="95" Height="16" IsIndeterminate="{Binding IsBusy}" />
                 </StatusBarItem>
-                <Separator />
-                <StatusBarItem>
-                    <TextBlock Text="{Binding StatusMessage}" />
+                <Separator Grid.Column="1" />
+                <StatusBarItem Grid.Column="2">
+                    <TextBlock Text="{Binding StatusMessage}" Width="988" />
+                </StatusBarItem>
+                <Separator Grid.Column="3" />
+                <StatusBarItem Grid.Column="4">
+                    <CheckBox Name="IsDarkMode" Content="Dark Mode" Checked="IsDarkMode_Checked" Unchecked="IsDarkMode_Checked"></CheckBox>
                 </StatusBarItem>
             </StatusBar>
         </Grid>

--- a/src/Lime.Client.TestConsole/Views/SessionView.xaml
+++ b/src/Lime.Client.TestConsole/Views/SessionView.xaml
@@ -151,7 +151,7 @@
 
             <GridSplitter Grid.Column="1" Grid.RowSpan="4" Width="5" HorizontalAlignment="Left" VerticalAlignment="Stretch" />
 
-            <Grid Grid.Row="0" Grid.RowSpan="4" Grid.Column="2" Margin="10,0">
+            <Grid Grid.Row="0" Grid.RowSpan="4" Grid.Column="2">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="200*" />

--- a/src/Lime.Client.TestConsole/Views/SessionView.xaml
+++ b/src/Lime.Client.TestConsole/Views/SessionView.xaml
@@ -186,12 +186,13 @@
                                        HorizontalScrollBarVisibility="Auto"
                                        AcceptsReturn="True"
                                        AcceptsTab="True"
+                                       Name="JsonInput"
                                        Text="{Binding InputJson, UpdateSourceTrigger=PropertyChanged}" />
                     <StackPanel Grid.Row="1" Margin="0,5" Orientation="Horizontal">
                         <Button Content="_Indent" ToolTip="Indent the JSON input" Command="{Binding IndentCommand}" />
                         <Button Content="_Validate" ToolTip="Validates the JSON input" Command="{Binding ValidateCommand}" />
                         <Button Content="_Parse" ToolTip="Parse the input variables" Command="{Binding ParseCommand}" />
-                        <Button Content="_Send" ToolTip="Sends the JSON through the transport" Command="{Binding SendCommand}" />
+                        <Button Content="_Send" ToolTip="Sends the JSON through the transport" Command="{Binding SendCommand}" CommandParameter="{Binding ElementName=JsonInput,Path=Text}" />
                         <CheckBox Margin="0,0,5,0" VerticalAlignment="Center" Content="Parse before send" IsChecked="{Binding ParseBeforeSend}" />
                         <CheckBox Margin="0,0,5,0" VerticalAlignment="Center" Content="Clear after sent" IsChecked="{Binding ClearAfterSent}" />
                         <CheckBox Margin="0,0,5,0" VerticalAlignment="Center" Content="Send as raw" IsChecked="{Binding SendAsRaw}" IsEnabled="{Binding CanSendAsRaw}" />

--- a/src/Lime.Client.TestConsole/Views/SessionView.xaml
+++ b/src/Lime.Client.TestConsole/Views/SessionView.xaml
@@ -10,7 +10,8 @@
              xmlns:i="clr-namespace:System.Windows.Interactivity;assembly=System.Windows.Interactivity"
              d:DataContext="{d:DesignData /DesignData/SessionDesignData.xaml}"
              d:DesignHeight="768"
-             d:DesignWidth="1224">
+             d:DesignWidth="1224"
+             Name="UcSessionView">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="300*" />
@@ -134,7 +135,15 @@
                         <DataTemplate>
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock Text="{Binding TimestampFormat, Mode=OneWay}"></TextBlock>
-                                <TextBlock Margin="5,0,0,0" Text="{Binding Message}" Foreground="{Binding IsError, Converter={StaticResource IsErrorToBrushConverter}}"></TextBlock>
+                                <!--<TextBlock Margin="5,0,0,0" Text="{Binding Message}" Foreground="{Binding IsError, Converter={StaticResource IsErrorToBrushConverter}}"></TextBlock>-->
+                                <TextBlock Margin="5,0,0,0" Text="{Binding Message}">
+                                    <TextBlock.Foreground>
+                                        <MultiBinding Converter="{StaticResource IsErrorToBrushConverter }">
+                                            <Binding Path="IsError"/>
+                                            <Binding ElementName="UcSessionView" Path="Style"/>
+                                        </MultiBinding>
+                                    </TextBlock.Foreground>
+                                </TextBlock>
                             </StackPanel>
                         </DataTemplate>
                     </ListBox.ItemTemplate>

--- a/src/Lime.Client.TestConsole/Views/SessionView.xaml
+++ b/src/Lime.Client.TestConsole/Views/SessionView.xaml
@@ -32,10 +32,12 @@
                 </Style>
                 <Style TargetType="TextBox">
                     <Setter Property="Foreground" Value="White"></Setter>
+                    <Setter Property="CaretBrush" Value="White"></Setter>
                     <Setter Property="Background" Value="Transparent"></Setter>
                 </Style>
                 <Style TargetType="xctk:WatermarkTextBox">
                     <Setter Property="Foreground" Value="White"></Setter>
+                    <Setter Property="CaretBrush" Value="White"></Setter>
                     <Setter Property="Background" Value="Transparent"></Setter>
                 </Style>
                 <Style TargetType="ListBox">

--- a/src/Lime.Client.TestConsole/Views/SessionView.xaml.cs
+++ b/src/Lime.Client.TestConsole/Views/SessionView.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 
 namespace Lime.Client.TestConsole.Views
@@ -12,9 +13,12 @@ namespace Lime.Client.TestConsole.Views
         public SessionView()
         {
             InitializeComponent();
+            _darModeStyle = (Style)Resources["darkMode"];
         }
 
         private bool _autoScroll;
+        private Style _darModeStyle;
+
         private void ScrollViewer_ScrollChanged(object sender, ScrollChangedEventArgs e)
         {
             var scrollViewer = (ScrollViewer)sender;
@@ -48,14 +52,15 @@ namespace Lime.Client.TestConsole.Views
             scv.ScrollToVerticalOffset(scv.VerticalOffset - e.Delta);
             e.Handled = true;
         }
+
         private void IsDarkMode_Checked(object sender, RoutedEventArgs e)
         {
-            MenuItem darkMode = (MenuItem)sender;
+            var darkMode = (ToggleButton)sender;
 
-            if (darkMode.IsChecked)
+            if (darkMode.IsChecked == true)
             {
-                this.Style = (Style)Resources["darkMode"];
-                EnvelopesListBox.Style = (Style)Resources["darkMode"];
+                this.Style = _darModeStyle;
+                EnvelopesListBox.Style = _darModeStyle;
             }
             else
             {

--- a/src/Lime.Client.TestConsole/Views/SessionView.xaml.cs
+++ b/src/Lime.Client.TestConsole/Views/SessionView.xaml.cs
@@ -50,9 +50,9 @@ namespace Lime.Client.TestConsole.Views
         }
         private void IsDarkMode_Checked(object sender, RoutedEventArgs e)
         {
-            MenuItem isDarkMode = (MenuItem)sender;
+            MenuItem darkMode = (MenuItem)sender;
 
-            if (isDarkMode.IsChecked)
+            if (darkMode.IsChecked)
             {
                 this.Style = (Style)Resources["darkMode"];
                 EnvelopesListBox.Style = (Style)Resources["darkMode"];

--- a/src/Lime.Client.TestConsole/Views/SessionView.xaml.cs
+++ b/src/Lime.Client.TestConsole/Views/SessionView.xaml.cs
@@ -1,18 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
-using Xceed.Wpf.Toolkit;
 
 namespace Lime.Client.TestConsole.Views
 {
@@ -60,7 +48,20 @@ namespace Lime.Client.TestConsole.Views
             scv.ScrollToVerticalOffset(scv.VerticalOffset - e.Delta);
             e.Handled = true;
         }
+        private void IsDarkMode_Checked(object sender, RoutedEventArgs e)
+        {
+            MenuItem isDarkMode = (MenuItem)sender;
 
-
+            if (isDarkMode.IsChecked)
+            {
+                this.Style = (Style)Resources["darkMode"];
+                EnvelopesListBox.Style = (Style)Resources["darkMode"];
+            }
+            else
+            {
+                this.Style = null;
+                EnvelopesListBox.Style = null;
+            }
+        }
     }
 }


### PR DESCRIPTION
[FEATURE]
In this pull request, i'm implementing the [Dark Mode](https://blog.weekdone.com/why-you-should-switch-on-dark-mode/) design. To enable this mode will be a botton on the top of the interface and you just need to click to activate and click again to deactivate.

To make this works, I created a style and a button, in the button click event, we will change the user control style by components type (every textbox will receive same foreground and background configurations). Besides this, I changed some converters (used in errors and envelope stripped messages) to turn in a MultiValueConverter, allowing receiving the current path variable and the current control style (Converters can't acess the control state directly).

[BUG]
Solved a bug where every ping command result are displayed in the Json input field. To solve this, I changed the field used in the method to send the command and not plot again in the same property (there is a method that was changing the binded property in the ReplyMacro).

Preview Dark Mode - Window mode
![dark mode - window](https://user-images.githubusercontent.com/6129653/92725226-2f966d00-f342-11ea-906a-2db17495cb83.png)

Preview Dark Mode - Fullscreen
![dark mode - fullscreen](https://user-images.githubusercontent.com/6129653/92725288-4ccb3b80-f342-11ea-9fe5-0c916da65167.png)
