### PR TITLE
Create logic to turn the dark mode configuration persistent

### DIFF
--- a/src/Lime.Client.TestConsole/Properties/AssemblyInfo.cs
+++ b/src/Lime.Client.TestConsole/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.10.0.0")]
-[assembly: AssemblyFileVersion("0.10.0.0")]
+[assembly: AssemblyVersion("0.11.0.0")]
+[assembly: AssemblyFileVersion("0.11.0.0")]

--- a/src/Lime.Client.TestConsole/Views/SessionView.xaml
+++ b/src/Lime.Client.TestConsole/Views/SessionView.xaml
@@ -285,7 +285,7 @@
                 </StatusBarItem>
                 <Separator Grid.Column="3" />
                 <StatusBarItem Grid.Column="4">
-                    <CheckBox Name="IsDarkMode" Content="Dark Mode" Checked="IsDarkMode_Checked" Unchecked="IsDarkMode_Checked"></CheckBox>
+                    <CheckBox Name="IsDarkMode" Content="Dark Mode" IsChecked="{Binding DarkMode, UpdateSourceTrigger=PropertyChanged}" Checked="IsDarkMode_Checked" Unchecked="IsDarkMode_Checked"></CheckBox>
                 </StatusBarItem>
             </StatusBar>
         </Grid>


### PR DESCRIPTION
This pull request are changing the dark mode feature to allow save the user choice.

If the user marks the checkbox, a fill will be create in the AppData directory to save the configuration and in the application start we will search this file and bind the  value in the property to show the Dark Mode/Default mode correctly.