### PR TITLE
Feature/215063 add transport external auth on cli

### DIFF
--- a/src/Lime.Cli/Certificate/CertificateResolver.cs
+++ b/src/Lime.Cli/Certificate/CertificateResolver.cs
@@ -1,9 +1,9 @@
 ﻿using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 
-namespace Lime.Cli.Util
+namespace Lime.Cli.Certificate
 {
-    public static class CertificateUtil
+    public static class CertificateResolver
     {
         public static X509Certificate2 GetCertificateFromThumbprint(string certificateThumbprint)
         {

--- a/src/Lime.Cli/Certificate/CertificateResolver.cs
+++ b/src/Lime.Cli/Certificate/CertificateResolver.cs
@@ -7,6 +7,11 @@ namespace Lime.Cli.Certificate
     {
         public static X509Certificate2 GetCertificateFromThumbprint(string certificateThumbprint)
         {
+            if (string.IsNullOrWhiteSpace(certificateThumbprint))
+            {
+                return null;
+            }
+
             X509Certificate2 certificate = null;
             X509Store store;
 

--- a/src/Lime.Cli/ConnectionInformation.cs
+++ b/src/Lime.Cli/ConnectionInformation.cs
@@ -32,9 +32,9 @@ namespace Lime.Cli
         public Receipt Receipt { get; set; }
 
         /// <summary>
-        /// Thumbprint for the X509 Certificate
+        /// Thumbprint for the X509 Certificate to use as Transport Authentication
         /// </summary>
-        public string Thumbprint { get; set; }
+        public string CertificateThumbprint { get; set; }
 
         /// <summary>
         /// Domain role to use as Transport Authentication

--- a/src/Lime.Cli/ConnectionInformation.cs
+++ b/src/Lime.Cli/ConnectionInformation.cs
@@ -12,6 +12,11 @@ namespace Lime.Cli
         
         public string Key { get; set; }
 
+        /// <summary>
+        /// Token to be used with External Authentication
+        /// </summary>
+        public string Token { get; set; }
+
         public string Instance { get; set; }
 
         public Uri ServerUri { get; set; }

--- a/src/Lime.Cli/ConnectionInformation.cs
+++ b/src/Lime.Cli/ConnectionInformation.cs
@@ -17,6 +17,11 @@ namespace Lime.Cli
         /// </summary>
         public string Token { get; set; }
 
+        /// <summary>
+        /// Issuer to be used with External Authentication. Defaults to accounts.blip.ai
+        /// </summary>
+        public string Issuer { get; set; }
+
         public string Instance { get; set; }
 
         public Uri ServerUri { get; set; }

--- a/src/Lime.Cli/ConnectionInformation.cs
+++ b/src/Lime.Cli/ConnectionInformation.cs
@@ -1,5 +1,6 @@
 ﻿using Lime.Messaging.Resources;
 using Lime.Protocol;
+using Lime.Protocol.Security;
 using System;
 
 namespace Lime.Cli
@@ -29,5 +30,15 @@ namespace Lime.Cli
         public Presence Presence { get; set; }
 
         public Receipt Receipt { get; set; }
+
+        /// <summary>
+        /// Thumbprint for the X509 Certificate
+        /// </summary>
+        public string Thumbprint { get; set; }
+
+        /// <summary>
+        /// Domain role to use as Transport Authentication
+        /// </summary>
+        public DomainRole DomainRole { get; set; }
     }
 }

--- a/src/Lime.Cli/IConnectionOptions.cs
+++ b/src/Lime.Cli/IConnectionOptions.cs
@@ -28,7 +28,7 @@ namespace Lime.Cli
 
         string ReceiptEvents { get; }
 
-        string Thumbprint { get; }
+        string CertificateThumbprint { get; }
 
         DomainRole DomainRole { get; }
     }
@@ -69,7 +69,7 @@ namespace Lime.Cli
                 Key = options.Key,
                 Token = options.Token,
                 Issuer = options.Issuer,
-                Thumbprint = options.Thumbprint,
+                CertificateThumbprint = options.CertificateThumbprint,
                 DomainRole = options.DomainRole,
                 ServerUri = options.Uri,
                 Instance = options.Instance ?? $"{Environment.MachineName.ToLowerInvariant()}-cli",

--- a/src/Lime.Cli/IConnectionOptions.cs
+++ b/src/Lime.Cli/IConnectionOptions.cs
@@ -12,7 +12,11 @@ namespace Lime.Cli
         string Password { get; }
         
         string Key { get; }
-        
+
+        string Token { get; }
+
+        string Issuer { get; }
+
         string Instance { get; }
         
         Uri Uri { get; }
@@ -58,6 +62,8 @@ namespace Lime.Cli
                 Identity = options.Identity,
                 Password = options.Password,
                 Key = options.Key,
+                Token = options.Token,
+                Issuer = options.Issuer,
                 ServerUri = options.Uri,
                 Instance = options.Instance ?? $"{Environment.MachineName.ToLowerInvariant()}-cli",
                 Presence = presence,

--- a/src/Lime.Cli/IConnectionOptions.cs
+++ b/src/Lime.Cli/IConnectionOptions.cs
@@ -69,6 +69,8 @@ namespace Lime.Cli
                 Key = options.Key,
                 Token = options.Token,
                 Issuer = options.Issuer,
+                Thumbprint = options.Thumbprint,
+                DomainRole = options.DomainRole,
                 ServerUri = options.Uri,
                 Instance = options.Instance ?? $"{Environment.MachineName.ToLowerInvariant()}-cli",
                 Presence = presence,

--- a/src/Lime.Cli/IConnectionOptions.cs
+++ b/src/Lime.Cli/IConnectionOptions.cs
@@ -1,5 +1,6 @@
 ﻿using Lime.Messaging.Resources;
 using Lime.Protocol;
+using Lime.Protocol.Security;
 using System;
 using System.Linq;
 
@@ -26,6 +27,10 @@ namespace Lime.Cli
         string PresenceRoutingRule { get; }
 
         string ReceiptEvents { get; }
+
+        string Thumbprint { get; }
+
+        DomainRole DomainRole { get; }
     }
 
     public static class ConnectionOptionExtensions

--- a/src/Lime.Cli/Lime.Cli.csproj
+++ b/src/Lime.Cli/Lime.Cli.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <Company>LIME</Company>
     <Product>LIME Protocol</Product>

--- a/src/Lime.Cli/Options.cs
+++ b/src/Lime.Cli/Options.cs
@@ -1,5 +1,6 @@
 ﻿
 using CommandLine;
+using Lime.Protocol.Security;
 using System;
 
 namespace Lime.Cli
@@ -41,5 +42,11 @@ namespace Lime.Cli
 
         [Option(HelpText = "The action to be executed in the non-interactive mode.")]
         public string Action { get; set; }
+
+        [Option(HelpText = "The thumbprint of the X509 certificate to be used.")]
+        public string Thumbprint { get; set; }
+
+        [Option(HelpText = "The DomainRole to be used on Transport Authentication.", Default = DomainRole.Authority)]
+        public DomainRole DomainRole { get; set; }
     }
 }

--- a/src/Lime.Cli/Options.cs
+++ b/src/Lime.Cli/Options.cs
@@ -15,6 +15,12 @@ namespace Lime.Cli
         [Option(HelpText = "The access key for using key authentication.")]
         public string Key { get; set; }
 
+        [Option(HelpText = "The token to be used on External Authentication")]
+        public string Token { get; set; }
+
+        [Option(HelpText = "The issuer to be used on External Authentication", Default = "account.blip.ai")]
+        public string Issuer { get; set; }
+
         [Option(HelpText = "The session instance name.")]
         public string Instance { get; set; }
 

--- a/src/Lime.Cli/Options.cs
+++ b/src/Lime.Cli/Options.cs
@@ -44,7 +44,7 @@ namespace Lime.Cli
         public string Action { get; set; }
 
         [Option(HelpText = "The thumbprint of the X509 certificate to be used.")]
-        public string Thumbprint { get; set; }
+        public string CertificateThumbprint { get; set; }
 
         [Option(HelpText = "The DomainRole to be used on Transport Authentication.", Default = DomainRole.Authority)]
         public DomainRole DomainRole { get; set; }

--- a/src/Lime.Cli/Options.cs
+++ b/src/Lime.Cli/Options.cs
@@ -43,7 +43,7 @@ namespace Lime.Cli
         [Option(HelpText = "The action to be executed in the non-interactive mode.")]
         public string Action { get; set; }
 
-        [Option(HelpText = "The thumbprint of the X509 certificate to be used.")]
+        [Option(HelpText = "Thumbprint for the X509 Certificate to use as Transport Authentication.")]
         public string CertificateThumbprint { get; set; }
 
         [Option(HelpText = "The DomainRole to be used on Transport Authentication.", Default = DomainRole.Authority)]

--- a/src/Lime.Cli/Program.cs
+++ b/src/Lime.Cli/Program.cs
@@ -259,6 +259,10 @@ namespace Lime.Cli
             {
                 builder = builder.WithKeyAuthentication(connectionInformation.Key);
             }
+            else if (connectionInformation.Token != null)
+            {
+                builder = builder.WithExternalAuthentication(connectionInformation.Token);
+            }
 
             var clientChannel = new OnDemandClientChannel(builder);
 

--- a/src/Lime.Cli/Program.cs
+++ b/src/Lime.Cli/Program.cs
@@ -1,7 +1,7 @@
 ﻿using CommandLine;
 using CommandLine.Text;
 using Lime.Cli.Actions;
-using Lime.Cli.Util;
+using Lime.Cli.Certificate;
 using Lime.Messaging;
 using Lime.Messaging.Resources;
 using Lime.Protocol;
@@ -9,7 +9,6 @@ using Lime.Protocol.Client;
 using Lime.Protocol.Listeners;
 using Lime.Protocol.Network;
 using Lime.Protocol.Network.Modules;
-using Lime.Protocol.Security;
 using Lime.Protocol.Serialization;
 using Lime.Protocol.Serialization.Newtonsoft;
 using Lime.Protocol.Util;
@@ -19,8 +18,6 @@ using SimpleInjector;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
-using System.Net.Mime;
 using System.Net.Security;
 using System.Net.WebSockets;
 using System.Reflection;
@@ -218,7 +215,7 @@ namespace Lime.Cli
 
         private static async Task<IOnDemandClientChannel> EstablishChannelAsync(ConnectionInformation connectionInformation, CancellationToken cancellationToken)
         {
-            var certificate = CertificateUtil.GetCertificateFromThumbprint(connectionInformation.Thumbprint);
+            var certificate = CertificateResolver.GetCertificateFromThumbprint(connectionInformation.Thumbprint);
             ITransport transportFactory() => CreateTransportForUri(connectionInformation.ServerUri, certificate);
 
             // Creates a new client channel

--- a/src/Lime.Cli/Program.cs
+++ b/src/Lime.Cli/Program.cs
@@ -265,7 +265,9 @@ namespace Lime.Cli
             }
             else if (connectionInformation.Thumbprint != null)
             {
-                builder = builder.WithTransportAuthentication(connectionInformation.DomainRole);
+                builder = builder
+                    .WithTransportAuthentication(connectionInformation.DomainRole)
+                    .WithEncryption(SessionEncryption.TLS);
             }
 
             var clientChannel = new OnDemandClientChannel(builder);

--- a/src/Lime.Cli/Program.cs
+++ b/src/Lime.Cli/Program.cs
@@ -215,7 +215,7 @@ namespace Lime.Cli
 
         private static async Task<IOnDemandClientChannel> EstablishChannelAsync(ConnectionInformation connectionInformation, CancellationToken cancellationToken)
         {
-            var certificate = CertificateResolver.GetCertificateFromThumbprint(connectionInformation.Thumbprint);
+            var certificate = CertificateResolver.GetCertificateFromThumbprint(connectionInformation.CertificateThumbprint);
             ITransport transportFactory() => CreateTransportForUri(connectionInformation.ServerUri, certificate);
 
             // Creates a new client channel
@@ -263,7 +263,7 @@ namespace Lime.Cli
             {
                 builder = builder.WithExternalAuthentication(connectionInformation.Token, connectionInformation.Issuer);
             }
-            else if (connectionInformation.Thumbprint != null)
+            else if (connectionInformation.CertificateThumbprint != null)
             {
                 builder = builder
                     .WithTransportAuthentication(connectionInformation.DomainRole)

--- a/src/Lime.Cli/Program.cs
+++ b/src/Lime.Cli/Program.cs
@@ -1,6 +1,7 @@
 ﻿using CommandLine;
 using CommandLine.Text;
 using Lime.Cli.Actions;
+using Lime.Cli.Util;
 using Lime.Messaging;
 using Lime.Messaging.Resources;
 using Lime.Protocol;
@@ -23,6 +24,7 @@ using System.Net.Mime;
 using System.Net.Security;
 using System.Net.WebSockets;
 using System.Reflection;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -216,7 +218,8 @@ namespace Lime.Cli
 
         private static async Task<IOnDemandClientChannel> EstablishChannelAsync(ConnectionInformation connectionInformation, CancellationToken cancellationToken)
         {
-            ITransport transportFactory() => CreateTransportForUri(connectionInformation.ServerUri);
+            var certificate = CertificateUtil.GetCertificateFromThumbprint(connectionInformation.Thumbprint);
+            ITransport transportFactory() => CreateTransportForUri(connectionInformation.ServerUri, certificate);
 
             // Creates a new client channel
             var builder = ClientChannelBuilder
@@ -263,6 +266,10 @@ namespace Lime.Cli
             {
                 builder = builder.WithExternalAuthentication(connectionInformation.Token, connectionInformation.Issuer);
             }
+            else if (connectionInformation.Thumbprint != null)
+            {
+                builder = builder.WithTransportAuthentication(connectionInformation.DomainRole);
+            }
 
             var clientChannel = new OnDemandClientChannel(builder);
 
@@ -295,14 +302,15 @@ namespace Lime.Cli
             return clientChannel;
         }
 
-        private static ITransport CreateTransportForUri(Uri uri)
+        private static ITransport CreateTransportForUri(Uri uri, X509Certificate2 certificate = null)
         {                        
             switch (uri.Scheme)
             {
                 case "net.tcp":
                     return new TcpTransport(
                         new EnvelopeSerializer(
-                            new DocumentTypeResolver().WithMessagingDocuments()));
+                            new DocumentTypeResolver().WithMessagingDocuments()),
+                        clientCertificate: certificate);
                 case "ws":
                 case "wss":
                     var webSocket = new ClientWebSocket();

--- a/src/Lime.Cli/Program.cs
+++ b/src/Lime.Cli/Program.cs
@@ -261,7 +261,7 @@ namespace Lime.Cli
             }
             else if (connectionInformation.Token != null)
             {
-                builder = builder.WithExternalAuthentication(connectionInformation.Token);
+                builder = builder.WithExternalAuthentication(connectionInformation.Token, connectionInformation.Issuer);
             }
 
             var clientChannel = new OnDemandClientChannel(builder);

--- a/src/Lime.Cli/Util/CertificateUtil.cs
+++ b/src/Lime.Cli/Util/CertificateUtil.cs
@@ -1,0 +1,43 @@
+﻿using System.Runtime.InteropServices;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Lime.Cli.Util
+{
+    public static class CertificateUtil
+    {
+        public static X509Certificate2 GetCertificateFromThumbprint(string certificateThumbprint)
+        {
+            X509Certificate2 certificate = null;
+            X509Store store;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                store = new X509Store(StoreName.My, StoreLocation.LocalMachine);
+            }
+            else
+            {
+                // .NET Core on linux doesn't load the private keys of certificate when using LocalMachine store.
+                // Besides that, it only supports the 'Root' and 'CertificateAuthority' stores on LocalMachine.
+                // https://github.com/dotnet/corefx/issues/32367
+                // https://serverfault.com/questions/259302/best-location-for-ssl-certificate-and-private-keys-on-ubuntu
+                // It is required to install the certificate programatically in the "CurrentUser" store (a concept that doesn't exists on linux).
+                // You should load the .pfx file to the linux server and create a C# program to install the certificate there.
+                // https://stackoverflow.com/questions/43660786/get-private-key-with-dotnet-core-on-linux
+                // https://github.com/dotnet/corefx/issues/16879
+                store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
+            }
+
+            store.Open(OpenFlags.ReadOnly);
+
+            var certificates = store.Certificates.Find(X509FindType.FindByThumbprint, certificateThumbprint, false);
+
+            if (certificates.Count > 0)
+            {
+                certificate = certificates[0];
+            }
+
+            store.Close();
+            return certificate;
+        }
+    }
+}

--- a/src/Lime.Protocol.UnitTests/Client/EstablishedClientChannelBuilderTests.cs
+++ b/src/Lime.Protocol.UnitTests/Client/EstablishedClientChannelBuilderTests.cs
@@ -274,6 +274,25 @@ namespace Lime.Protocol.UnitTests.Client
         }
 
         [Test]
+        public async Task WithTransportAuthentication_AuthorityRole_EstablishesSessionWithSelectedOption()
+        {
+            // Arrange                        
+            var target = GetTarget();
+
+            // Act            
+            target.WithTransportAuthentication(DomainRole.Authority);
+            var channel = await target.BuildAndEstablishAsync(_cancellationToken);
+
+            // Assert
+            _clientChannel.Verify(c => c.AuthenticateSessionAsync(
+                It.IsAny<Identity>(),
+                It.Is<Authentication>(a => a is TransportAuthentication && ((TransportAuthentication)a).DomainRole.Equals(DomainRole.Authority)),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Test]
         public async Task WithPlainAuthentication_AnyPassword_EstablishesSessionWithSelectedOption()
         {
             // Arrange                        

--- a/src/Lime.Protocol.UnitTests/Client/EstablishedClientChannelBuilderTests.cs
+++ b/src/Lime.Protocol.UnitTests/Client/EstablishedClientChannelBuilderTests.cs
@@ -240,6 +240,40 @@ namespace Lime.Protocol.UnitTests.Client
         }
 
         [Test]
+        public async Task WithExternalAuthentication_AnyToken_EstablishesSessionWithSelectedOption()
+        {
+            // Arrange                        
+            var token = Dummy.CreateRandomString(100);
+            var issuer = "account.blip.ai";
+            var target = GetTarget();
+
+            // Act            
+            target.WithExternalAuthentication(token, issuer);
+            var channel = await target.BuildAndEstablishAsync(_cancellationToken);
+
+            // Assert
+            _clientChannel.Verify(c => c.AuthenticateSessionAsync(
+                It.IsAny<Identity>(),
+                It.Is<Authentication>(a => a is ExternalAuthentication && ((ExternalAuthentication)a).GetFromBase64Token().Equals(token)),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Test]
+        public void WithExternalAuthentication_NullToken_ThrowsArgumentNullException()
+        {
+            // Arrange                        
+            string token = null;
+            var issuer = "account.blip.ai";
+            var target = GetTarget();
+
+            // Act            
+            Action action = () => target.WithExternalAuthentication(token, issuer);
+            action.ShouldThrow<ArgumentNullException>();
+        }
+
+        [Test]
         public async Task WithPlainAuthentication_AnyPassword_EstablishesSessionWithSelectedOption()
         {
             // Arrange                        

--- a/src/Lime.Protocol/Client/EstablishedClientChannelBuilder.cs
+++ b/src/Lime.Protocol/Client/EstablishedClientChannelBuilder.cs
@@ -174,7 +174,7 @@ namespace Lime.Protocol.Client
             return WithAuthentication(authentication);
         }
 
-        public IEstablishedClientChannelBuilder WithExternalAuthentication(string token)
+        public IEstablishedClientChannelBuilder WithExternalAuthentication(string token, string )
         {
             if (token == null)
             {

--- a/src/Lime.Protocol/Client/EstablishedClientChannelBuilder.cs
+++ b/src/Lime.Protocol/Client/EstablishedClientChannelBuilder.cs
@@ -174,6 +174,18 @@ namespace Lime.Protocol.Client
             return WithAuthentication(authentication);
         }
 
+        public IEstablishedClientChannelBuilder WithTransportAuthentication(DomainRole domainRole)
+        {
+            if (domainRole == null)
+            {
+                throw new ArgumentNullException(nameof(domainRole));
+            }
+
+            var authentication = new TransportAuthentication();
+            authentication.DomainRole = domainRole;
+            return WithAuthentication(authentication);
+        }
+
         public IEstablishedClientChannelBuilder WithExternalAuthentication(string token, string issuer)
         {
             if (token == null)

--- a/src/Lime.Protocol/Client/EstablishedClientChannelBuilder.cs
+++ b/src/Lime.Protocol/Client/EstablishedClientChannelBuilder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Dawn;
 using Lime.Protocol.Network;
 using Lime.Protocol.Security;
 
@@ -102,10 +103,7 @@ namespace Lime.Protocol.Client
         /// <exception cref="System.ArgumentNullException"></exception>
         public IEstablishedClientChannelBuilder WithCompression(Func<SessionCompression[], SessionCompression> compressionSelector)
         {
-            if (compressionSelector == null)
-            {
-                throw new ArgumentNullException(nameof(compressionSelector));
-            }
+            Guard.Argument(compressionSelector, nameof(compressionSelector)).NotNull();
 
             CompressionSelector = compressionSelector;
             return this;
@@ -129,10 +127,7 @@ namespace Lime.Protocol.Client
         /// <exception cref="System.ArgumentNullException"></exception>
         public IEstablishedClientChannelBuilder WithEncryption(Func<SessionEncryption[], SessionEncryption> encryptionSelector)
         {
-            if (encryptionSelector == null)
-            {
-                throw new ArgumentNullException(nameof(encryptionSelector));
-            }
+            Guard.Argument(encryptionSelector, nameof(encryptionSelector)).NotNull();
 
             EncryptionSelector = encryptionSelector;
             return this;
@@ -146,10 +141,7 @@ namespace Lime.Protocol.Client
         /// <exception cref="System.ArgumentNullException"></exception>
         public IEstablishedClientChannelBuilder WithPlainAuthentication(string password)
         {
-            if (password == null)
-            {
-                throw new ArgumentNullException(nameof(password));
-            }
+            Guard.Argument(password, nameof(password)).NotNull();
 
             var authentication = new PlainAuthentication();
             authentication.SetToBase64Password(password);
@@ -164,10 +156,7 @@ namespace Lime.Protocol.Client
         /// <exception cref="System.ArgumentNullException"></exception>
         public IEstablishedClientChannelBuilder WithKeyAuthentication(string key)
         {
-            if (key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
+            Guard.Argument(key, nameof(key)).NotNull();
 
             var authentication = new KeyAuthentication();
             authentication.SetToBase64Key(key);
@@ -183,10 +172,7 @@ namespace Lime.Protocol.Client
 
         public IEstablishedClientChannelBuilder WithExternalAuthentication(string token, string issuer)
         {
-            if (token == null)
-            {
-                throw new ArgumentNullException(nameof(token));
-            }
+            Guard.Argument(token, nameof(token)).NotNull();
 
             var authentication = new ExternalAuthentication
             {
@@ -214,10 +200,7 @@ namespace Lime.Protocol.Client
         /// <exception cref="System.ArgumentNullException"></exception>
         public IEstablishedClientChannelBuilder WithAuthentication(Authentication authentication)
         {
-            if (authentication == null)
-            {
-                throw new ArgumentNullException(nameof(authentication));
-            }
+            Guard.Argument(authentication, nameof(authentication)).NotNull();
 
             return WithAuthentication((schemes, roundtrip) => authentication);
         }
@@ -230,10 +213,7 @@ namespace Lime.Protocol.Client
         /// <exception cref="System.ArgumentNullException"></exception>
         public IEstablishedClientChannelBuilder WithAuthentication(Func<AuthenticationScheme[], Authentication, Authentication> authenticator)
         {
-            if (authenticator == null)
-            {
-                throw new ArgumentNullException(nameof(authenticator));
-            }
+            Guard.Argument(authenticator, nameof(authenticator)).NotNull();
 
             Authenticator = authenticator;
             return this;
@@ -247,11 +227,8 @@ namespace Lime.Protocol.Client
         /// <exception cref="System.ArgumentNullException"></exception>
         public IEstablishedClientChannelBuilder WithIdentity(Identity identity)
         {
-            if (identity == null)
-            {
-                throw new ArgumentNullException(nameof(identity));
-            }
-
+            Guard.Argument(identity, nameof(identity)).NotNull();
+            
             Identity = identity;
             return this;
         }
@@ -264,10 +241,7 @@ namespace Lime.Protocol.Client
         /// <exception cref="System.ArgumentNullException"></exception>
         public IEstablishedClientChannelBuilder WithInstance(string instance)
         {
-            if (instance == null)
-            {
-                throw new ArgumentNullException(nameof(instance));
-            }
+            Guard.Argument(instance, nameof(instance)).NotNull();
 
             Instance = instance;
             return this;
@@ -281,11 +255,8 @@ namespace Lime.Protocol.Client
         /// <exception cref="System.ArgumentNullException"></exception>
         public IEstablishedClientChannelBuilder AddEstablishedHandler(Func<IClientChannel, CancellationToken, Task> establishedHandler)
         {
-            if (establishedHandler == null)
-            {
-                throw new ArgumentNullException(nameof(establishedHandler));
-            }
-
+            Guard.Argument(establishedHandler, nameof(establishedHandler)).NotNull();
+            
             _establishedHandlers.Add(establishedHandler);
             return this;
         }

--- a/src/Lime.Protocol/Client/EstablishedClientChannelBuilder.cs
+++ b/src/Lime.Protocol/Client/EstablishedClientChannelBuilder.cs
@@ -13,6 +13,7 @@ namespace Lime.Protocol.Client
     /// </summary>
     public sealed class EstablishedClientChannelBuilder : IEstablishedClientChannelBuilder
     {
+        private const string DEFAULT_EXTERNAL_AUTH_ISSUER = "account.blip.ai";
         private readonly List<Func<IClientChannel, CancellationToken, Task>> _establishedHandlers;
 
         /// <summary>
@@ -174,7 +175,7 @@ namespace Lime.Protocol.Client
             return WithAuthentication(authentication);
         }
 
-        public IEstablishedClientChannelBuilder WithExternalAuthentication(string token, string )
+        public IEstablishedClientChannelBuilder WithExternalAuthentication(string token, string issuer = DEFAULT_EXTERNAL_AUTH_ISSUER)
         {
             if (token == null)
             {
@@ -183,6 +184,7 @@ namespace Lime.Protocol.Client
 
             var authentication = new ExternalAuthentication();
             authentication.SetToBase64Token(token);
+            authentication.Issuer = issuer;
             return WithAuthentication(authentication);
         }
 

--- a/src/Lime.Protocol/Client/EstablishedClientChannelBuilder.cs
+++ b/src/Lime.Protocol/Client/EstablishedClientChannelBuilder.cs
@@ -13,7 +13,6 @@ namespace Lime.Protocol.Client
     /// </summary>
     public sealed class EstablishedClientChannelBuilder : IEstablishedClientChannelBuilder
     {
-        private const string DEFAULT_EXTERNAL_AUTH_ISSUER = "account.blip.ai";
         private readonly List<Func<IClientChannel, CancellationToken, Task>> _establishedHandlers;
 
         /// <summary>
@@ -175,7 +174,7 @@ namespace Lime.Protocol.Client
             return WithAuthentication(authentication);
         }
 
-        public IEstablishedClientChannelBuilder WithExternalAuthentication(string token, string issuer = DEFAULT_EXTERNAL_AUTH_ISSUER)
+        public IEstablishedClientChannelBuilder WithExternalAuthentication(string token, string issuer)
         {
             if (token == null)
             {

--- a/src/Lime.Protocol/Client/EstablishedClientChannelBuilder.cs
+++ b/src/Lime.Protocol/Client/EstablishedClientChannelBuilder.cs
@@ -102,7 +102,11 @@ namespace Lime.Protocol.Client
         /// <exception cref="System.ArgumentNullException"></exception>
         public IEstablishedClientChannelBuilder WithCompression(Func<SessionCompression[], SessionCompression> compressionSelector)
         {
-            if (compressionSelector == null) throw new ArgumentNullException(nameof(compressionSelector));
+            if (compressionSelector == null)
+            {
+                throw new ArgumentNullException(nameof(compressionSelector));
+            }
+
             CompressionSelector = compressionSelector;
             return this;
         }
@@ -125,7 +129,11 @@ namespace Lime.Protocol.Client
         /// <exception cref="System.ArgumentNullException"></exception>
         public IEstablishedClientChannelBuilder WithEncryption(Func<SessionEncryption[], SessionEncryption> encryptionSelector)
         {
-            if (encryptionSelector == null) throw new ArgumentNullException(nameof(encryptionSelector));
+            if (encryptionSelector == null)
+            {
+                throw new ArgumentNullException(nameof(encryptionSelector));
+            }
+
             EncryptionSelector = encryptionSelector;
             return this;
         }
@@ -138,7 +146,11 @@ namespace Lime.Protocol.Client
         /// <exception cref="System.ArgumentNullException"></exception>
         public IEstablishedClientChannelBuilder WithPlainAuthentication(string password)
         {
-            if (password == null) throw new ArgumentNullException(nameof(password));
+            if (password == null)
+            {
+                throw new ArgumentNullException(nameof(password));
+            }
+
             var authentication = new PlainAuthentication();
             authentication.SetToBase64Password(password);
             return WithAuthentication(authentication);
@@ -152,9 +164,25 @@ namespace Lime.Protocol.Client
         /// <exception cref="System.ArgumentNullException"></exception>
         public IEstablishedClientChannelBuilder WithKeyAuthentication(string key)
         {
-            if (key == null) throw new ArgumentNullException(nameof(key));
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
             var authentication = new KeyAuthentication();
             authentication.SetToBase64Key(key);
+            return WithAuthentication(authentication);
+        }
+
+        public IEstablishedClientChannelBuilder WithExternalAuthentication(string token)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            var authentication = new ExternalAuthentication();
+            authentication.SetToBase64Token(token);
             return WithAuthentication(authentication);
         }
 
@@ -176,7 +204,11 @@ namespace Lime.Protocol.Client
         /// <exception cref="System.ArgumentNullException"></exception>
         public IEstablishedClientChannelBuilder WithAuthentication(Authentication authentication)
         {
-            if (authentication == null) throw new ArgumentNullException(nameof(authentication));
+            if (authentication == null)
+            {
+                throw new ArgumentNullException(nameof(authentication));
+            }
+
             return WithAuthentication((schemes, roundtrip) => authentication);
         }
 
@@ -188,7 +220,11 @@ namespace Lime.Protocol.Client
         /// <exception cref="System.ArgumentNullException"></exception>
         public IEstablishedClientChannelBuilder WithAuthentication(Func<AuthenticationScheme[], Authentication, Authentication> authenticator)
         {
-            if (authenticator == null) throw new ArgumentNullException(nameof(authenticator));
+            if (authenticator == null)
+            {
+                throw new ArgumentNullException(nameof(authenticator));
+            }
+
             Authenticator = authenticator;
             return this;
         }
@@ -201,7 +237,11 @@ namespace Lime.Protocol.Client
         /// <exception cref="System.ArgumentNullException"></exception>
         public IEstablishedClientChannelBuilder WithIdentity(Identity identity)
         {
-            if (identity == null) throw new ArgumentNullException(nameof(identity));
+            if (identity == null)
+            {
+                throw new ArgumentNullException(nameof(identity));
+            }
+
             Identity = identity;
             return this;
         }
@@ -214,7 +254,11 @@ namespace Lime.Protocol.Client
         /// <exception cref="System.ArgumentNullException"></exception>
         public IEstablishedClientChannelBuilder WithInstance(string instance)
         {
-            if (instance == null) throw new ArgumentNullException(nameof(instance));
+            if (instance == null)
+            {
+                throw new ArgumentNullException(nameof(instance));
+            }
+
             Instance = instance;
             return this;
         }
@@ -227,7 +271,11 @@ namespace Lime.Protocol.Client
         /// <exception cref="System.ArgumentNullException"></exception>
         public IEstablishedClientChannelBuilder AddEstablishedHandler(Func<IClientChannel, CancellationToken, Task> establishedHandler)
         {
-            if (establishedHandler == null) throw new ArgumentNullException(nameof(establishedHandler));
+            if (establishedHandler == null)
+            {
+                throw new ArgumentNullException(nameof(establishedHandler));
+            }
+
             _establishedHandlers.Add(establishedHandler);
             return this;
         }
@@ -238,7 +286,7 @@ namespace Lime.Protocol.Client
         /// <returns></returns>
         public IEstablishedClientChannelBuilder Copy()
         {
-            return (IEstablishedClientChannelBuilder) MemberwiseClone();
+            return (IEstablishedClientChannelBuilder)MemberwiseClone();
         }
 
         /// <summary>
@@ -254,7 +302,6 @@ namespace Lime.Protocol.Client
 
             try
             {
-
                 Session session;
 
                 using (var cancellationTokenSource = new CancellationTokenSource(EstablishmentTimeout))

--- a/src/Lime.Protocol/Client/EstablishedClientChannelBuilder.cs
+++ b/src/Lime.Protocol/Client/EstablishedClientChannelBuilder.cs
@@ -188,9 +188,11 @@ namespace Lime.Protocol.Client
                 throw new ArgumentNullException(nameof(token));
             }
 
-            var authentication = new ExternalAuthentication();
-            authentication.SetToBase64Token(token);
-            authentication.Issuer = issuer;
+            var authentication = new ExternalAuthentication
+            {
+                Token = token,
+                Issuer = issuer
+            };
             return WithAuthentication(authentication);
         }
 

--- a/src/Lime.Protocol/Client/EstablishedClientChannelBuilder.cs
+++ b/src/Lime.Protocol/Client/EstablishedClientChannelBuilder.cs
@@ -176,11 +176,6 @@ namespace Lime.Protocol.Client
 
         public IEstablishedClientChannelBuilder WithTransportAuthentication(DomainRole domainRole)
         {
-            if (domainRole == null)
-            {
-                throw new ArgumentNullException(nameof(domainRole));
-            }
-
             var authentication = new TransportAuthentication();
             authentication.DomainRole = domainRole;
             return WithAuthentication(authentication);

--- a/src/Lime.Protocol/Client/IEstablishedClientChannelBuilder.cs
+++ b/src/Lime.Protocol/Client/IEstablishedClientChannelBuilder.cs
@@ -111,6 +111,14 @@ namespace Lime.Protocol.Client
         IEstablishedClientChannelBuilder WithExternalAuthentication(string token, string issuer);
 
         /// <summary>
+        /// Set the domain role to be used in the session establishment
+        /// </summary>
+        /// <param name="domainRole"></param>
+        /// <returns></returns>
+        /// <exception cref="System.ArgumentNullException"></exception>
+        IEstablishedClientChannelBuilder WithTransportAuthentication(DomainRole domainRole);
+
+        /// <summary>
         /// Sets the authentication to be used in the session establishment.
         /// </summary>
         /// <returns></returns>

--- a/src/Lime.Protocol/Client/IEstablishedClientChannelBuilder.cs
+++ b/src/Lime.Protocol/Client/IEstablishedClientChannelBuilder.cs
@@ -102,6 +102,14 @@ namespace Lime.Protocol.Client
         IEstablishedClientChannelBuilder WithKeyAuthentication(string key);
 
         /// <summary>
+        /// Set the external authentication token to be used in the session establishment.
+        /// </summary>
+        /// <param name="token">The authentication token</param>
+        /// <returns></returns>
+        /// <exception cref="System.ArgumentNullException"></exception>
+        IEstablishedClientChannelBuilder WithExternalAuthentication(string token);
+
+        /// <summary>
         /// Sets the authentication to be used in the session establishment.
         /// </summary>
         /// <returns></returns>

--- a/src/Lime.Protocol/Client/IEstablishedClientChannelBuilder.cs
+++ b/src/Lime.Protocol/Client/IEstablishedClientChannelBuilder.cs
@@ -105,9 +105,10 @@ namespace Lime.Protocol.Client
         /// Set the external authentication token to be used in the session establishment.
         /// </summary>
         /// <param name="token">The authentication token</param>
+        /// <param name="issuer"></param>
         /// <returns></returns>
         /// <exception cref="System.ArgumentNullException"></exception>
-        IEstablishedClientChannelBuilder WithExternalAuthentication(string token);
+        IEstablishedClientChannelBuilder WithExternalAuthentication(string token, string issuer);
 
         /// <summary>
         /// Sets the authentication to be used in the session establishment.

--- a/src/Lime.Protocol/Lime.Protocol.csproj
+++ b/src/Lime.Protocol/Lime.Protocol.csproj
@@ -16,6 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Dawn.Guard" Version="1.12.0" />
     <PackageReference Include="System.Memory" Version="4.5.3" />
     <PackageReference Include="System.Threading.Channels" Version="4.7.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.10.0" />

--- a/src/Lime.Transport.WebSocket/X509CertificateInfo.cs
+++ b/src/Lime.Transport.WebSocket/X509CertificateInfo.cs
@@ -11,13 +11,13 @@ namespace Lime.Transport.WebSocket
         /// <summary>
         /// Initializes a new instance of the <see cref="X509CertificateInfo"/> class.
         /// </summary>
-        /// <param name="thumbprint">The thumbprint.</param>
+        /// <param name="certificateThumbprint">The thumbprint.</param>
         /// <param name="store">The store.</param>
         /// <exception cref="ArgumentNullException"></exception>
-        public X509CertificateInfo(string thumbprint, StoreName store = StoreName.My)
+        public X509CertificateInfo(string certificateThumbprint, StoreName store = StoreName.My)
         {
-            if (thumbprint == null) throw new ArgumentNullException(nameof(thumbprint));
-            Thumbprint = thumbprint;
+            if (certificateThumbprint == null) throw new ArgumentNullException(nameof(certificateThumbprint));
+            CertificateThumbprint = certificateThumbprint;
             Store = store;
         }
 
@@ -27,7 +27,7 @@ namespace Lime.Transport.WebSocket
         /// <value>
         /// The thumbprint.
         /// </value>
-        public string Thumbprint { get; }
+        public string CertificateThumbprint { get; }
 
         /// <summary>
         /// Gets the certificate store.
@@ -35,6 +35,6 @@ namespace Lime.Transport.WebSocket
         /// <value>
         /// The store.
         /// </value>
-        public StoreName Store { get; }        
+        public StoreName Store { get; }
     }
 }

--- a/src/Lime.Transport.WebSocket/X509CertificateInfo.cs
+++ b/src/Lime.Transport.WebSocket/X509CertificateInfo.cs
@@ -11,13 +11,13 @@ namespace Lime.Transport.WebSocket
         /// <summary>
         /// Initializes a new instance of the <see cref="X509CertificateInfo"/> class.
         /// </summary>
-        /// <param name="certificateThumbprint">The thumbprint.</param>
+        /// <param name="thumbprint">The thumbprint.</param>
         /// <param name="store">The store.</param>
         /// <exception cref="ArgumentNullException"></exception>
-        public X509CertificateInfo(string certificateThumbprint, StoreName store = StoreName.My)
+        public X509CertificateInfo(string thumbprint, StoreName store = StoreName.My)
         {
-            if (certificateThumbprint == null) throw new ArgumentNullException(nameof(certificateThumbprint));
-            CertificateThumbprint = certificateThumbprint;
+            if (thumbprint == null) throw new ArgumentNullException(nameof(thumbprint));
+            Thumbprint = thumbprint;
             Store = store;
         }
 
@@ -27,7 +27,7 @@ namespace Lime.Transport.WebSocket
         /// <value>
         /// The thumbprint.
         /// </value>
-        public string CertificateThumbprint { get; }
+        public string Thumbprint { get; }
 
         /// <summary>
         /// Gets the certificate store.


### PR DESCRIPTION
Adds the possibility of External and Transport authentication methods on Lime.Cli for a more thorough testing environment