### PR TITLE
Decreasing timeout when closing transport

### DIFF
--- a/src/Lime.Protocol/Network/ChannelBase.cs
+++ b/src/Lime.Protocol/Network/ChannelBase.cs
@@ -89,7 +89,8 @@ namespace Lime.Protocol.Network
                 CommandModules, 
                 HandleConsumerExceptionAsync,
                 envelopeBufferSize,
-                consumeTimeout);
+                consumeTimeout,
+                StopTimeout);
 
             _senderChannel = new SenderChannel(
                 this,
@@ -99,7 +100,8 @@ namespace Lime.Protocol.Network
                 CommandModules,
                 HandleSenderExceptionAsync,
                 envelopeBufferSize,
-                sendTimeout);
+                sendTimeout,
+                StopTimeout);
         }
 
         ~ChannelBase()
@@ -226,10 +228,10 @@ namespace Lime.Protocol.Network
         /// Stops the sender and receiver tasks.
         /// </summary>
         /// <returns></returns>
-        private async Task StopChannelTasks()
+        private Task StopChannelTasks()
         {
             using var cts = new CancellationTokenSource(StopTimeout);
-            await Task.WhenAll(
+            return Task.WhenAll(
                 _receiverChannel.StopAsync(cts.Token),
                 _senderChannel.StopAsync(cts.Token));
         }

--- a/src/Lime.Protocol/Network/ChannelBase.cs
+++ b/src/Lime.Protocol/Network/ChannelBase.cs
@@ -228,10 +228,10 @@ namespace Lime.Protocol.Network
         /// Stops the sender and receiver tasks.
         /// </summary>
         /// <returns></returns>
-        private Task StopChannelTasks()
+        private async Task StopChannelTasks()
         {
             using var cts = new CancellationTokenSource(StopTimeout);
-            return Task.WhenAll(
+            await Task.WhenAll(
                 _receiverChannel.StopAsync(cts.Token),
                 _senderChannel.StopAsync(cts.Token));
         }

--- a/src/Lime.Protocol/Network/ChannelBase.cs
+++ b/src/Lime.Protocol/Network/ChannelBase.cs
@@ -90,7 +90,7 @@ namespace Lime.Protocol.Network
                 HandleConsumerExceptionAsync,
                 envelopeBufferSize,
                 consumeTimeout,
-                StopTimeout);
+                _closeTimeout);
 
             _senderChannel = new SenderChannel(
                 this,
@@ -101,7 +101,7 @@ namespace Lime.Protocol.Network
                 HandleSenderExceptionAsync,
                 envelopeBufferSize,
                 sendTimeout,
-                StopTimeout);
+                _closeTimeout);
         }
 
         ~ChannelBase()

--- a/src/Lime.Protocol/Network/ReceiverChannel.cs
+++ b/src/Lime.Protocol/Network/ReceiverChannel.cs
@@ -272,7 +272,7 @@ namespace Lime.Protocol.Network
                 // Closes the transport in case of any exception
                 if (_transport.IsConnected)
                 {
-                    using var cts = new CancellationTokenSource(_closeTimeout);
+                    using var cts = new CancellationTokenSource(_closeTimeout.Value);
                     try
                     {
                         await _transport.CloseAsync(cts.Token).ConfigureAwait(false);

--- a/src/Lime.Protocol/Network/ReceiverChannel.cs
+++ b/src/Lime.Protocol/Network/ReceiverChannel.cs
@@ -19,6 +19,7 @@ namespace Lime.Protocol.Network
         private readonly ICollection<IChannelModule<Command>> _commandModules;
         private readonly Func<Exception, Task> _exceptionHandler;
         private readonly TimeSpan? _consumeTimeout;
+        private readonly TimeSpan? _closeTimeout;
         private readonly CancellationTokenSource _consumerCts;
         private readonly Channel<Message> _messageBuffer;
         private readonly Channel<Command> _commandBuffer;
@@ -39,7 +40,8 @@ namespace Lime.Protocol.Network
             ICollection<IChannelModule<Command>> commandModules,
             Func<Exception, Task> exceptionHandler,
             int envelopeBufferSize,
-            TimeSpan? consumeTimeout)
+            TimeSpan? consumeTimeout,
+            TimeSpan? closeTimeout = null)
         {
             if (consumeTimeout != null && consumeTimeout.Value == default) throw new ArgumentException("Invalid consume timeout", nameof(consumeTimeout));
             
@@ -51,6 +53,7 @@ namespace Lime.Protocol.Network
             _commandModules = commandModules;
             _exceptionHandler = exceptionHandler;
             _consumeTimeout = consumeTimeout;
+            _closeTimeout = closeTimeout ?? consumeTimeout ?? TimeSpan.FromSeconds(5);
             _sessionSemaphore = new SemaphoreSlim(1);
             _startStopSemaphore = new SemaphoreSlim(1);
             _consumerCts = new CancellationTokenSource();
@@ -269,7 +272,7 @@ namespace Lime.Protocol.Network
                 // Closes the transport in case of any exception
                 if (_transport.IsConnected)
                 {
-                    using var cts = new CancellationTokenSource(_consumeTimeout ?? TimeSpan.FromSeconds(5));
+                    using var cts = new CancellationTokenSource(_closeTimeout);
                     try
                     {
                         await _transport.CloseAsync(cts.Token).ConfigureAwait(false);

--- a/src/Lime.Protocol/Network/ReceiverChannel.cs
+++ b/src/Lime.Protocol/Network/ReceiverChannel.cs
@@ -19,7 +19,7 @@ namespace Lime.Protocol.Network
         private readonly ICollection<IChannelModule<Command>> _commandModules;
         private readonly Func<Exception, Task> _exceptionHandler;
         private readonly TimeSpan? _consumeTimeout;
-        private readonly TimeSpan? _closeTimeout;
+        private readonly TimeSpan _closeTimeout;
         private readonly CancellationTokenSource _consumerCts;
         private readonly Channel<Message> _messageBuffer;
         private readonly Channel<Command> _commandBuffer;
@@ -272,7 +272,7 @@ namespace Lime.Protocol.Network
                 // Closes the transport in case of any exception
                 if (_transport.IsConnected)
                 {
-                    using var cts = new CancellationTokenSource(_closeTimeout.Value);
+                    using var cts = new CancellationTokenSource(_closeTimeout);
                     try
                     {
                         await _transport.CloseAsync(cts.Token).ConfigureAwait(false);


### PR DESCRIPTION
Previously we were using the same timeout for sending envelope and closing the transport, which is a one minute timeout.
Now, we are using a 5 seconds timeout for closing the transport.