### PR TITLE
Prevent big payloads from sending on TcpTransport

### DIFF
--- a/src/Lime.Protocol/Network/ChannelBase.cs
+++ b/src/Lime.Protocol/Network/ChannelBase.cs
@@ -323,7 +323,7 @@ namespace Lime.Protocol.Network
                 _receiverChannel.Dispose();
                 _senderChannel.Dispose();
                 Transport.DisposeIfDisposable();
-                _remotePingChannelModule?.Dispose(); ;
+                _remotePingChannelModule?.Dispose();
             }
         }
     }

--- a/src/Lime.Protocol/Network/ChannelBase.cs
+++ b/src/Lime.Protocol/Network/ChannelBase.cs
@@ -15,13 +15,13 @@ namespace Lime.Protocol.Network
     {
         private static readonly TimeSpan ExceptionHandlerTimeout = TimeSpan.FromSeconds(5);
         private static readonly TimeSpan StopTimeout = TimeSpan.FromSeconds(5);
-        
+
         private readonly TimeSpan _closeTimeout;
         private readonly ReceiverChannel _receiverChannel;
         private readonly SenderChannel _senderChannel;
         private readonly IChannelCommandProcessor _channelCommandProcessor;
         private readonly IDisposable _remotePingChannelModule;
-        
+
         private SessionState _state;
         private bool _closeTransportInvoked;
 
@@ -79,14 +79,14 @@ namespace Lime.Protocol.Network
             {
                 _remotePingChannelModule = RemotePingChannelModule.CreateAndRegister(this, remotePingInterval.Value, remoteIdleTimeout);
             }
-            
+
             _receiverChannel = new ReceiverChannel(
                 this,
-                Transport, 
+                Transport,
                 _channelCommandProcessor,
                 MessageModules,
                 NotificationModules,
-                CommandModules, 
+                CommandModules,
                 HandleConsumerExceptionAsync,
                 envelopeBufferSize,
                 consumeTimeout,
@@ -138,13 +138,13 @@ namespace Lime.Protocol.Network
             protected set
             {
                 _state = value;
-                
+
                 if (_state == SessionState.Established)
                 {
                     _senderChannel.Start();
                     _receiverChannel.Start();
                 }
-                
+
                 OnStateChanged(MessageModules, _state);
                 OnStateChanged(NotificationModules, _state);
                 OnStateChanged(CommandModules, _state);
@@ -165,7 +165,7 @@ namespace Lime.Protocol.Network
 
         /// <inheritdoc />
         public event EventHandler<ExceptionEventArgs> SenderException;
-        
+
         /// <inheritdoc />
         public virtual Task SendMessageAsync(Message message, CancellationToken cancellationToken)
             => _senderChannel.SendMessageAsync(message, cancellationToken);
@@ -195,13 +195,13 @@ namespace Lime.Protocol.Network
             => _receiverChannel.ReceiveNotificationAsync(cancellationToken);
 
         /// <inheritdoc />
-        public virtual Task SendSessionAsync(Session session, CancellationToken cancellationToken) 
+        public virtual Task SendSessionAsync(Session session, CancellationToken cancellationToken)
             => _senderChannel.SendSessionAsync(session, cancellationToken);
 
         /// <inheritdoc />
-        public virtual Task<Session> ReceiveSessionAsync(CancellationToken cancellationToken) 
+        public virtual Task<Session> ReceiveSessionAsync(CancellationToken cancellationToken)
             => _receiverChannel.ReceiveSessionAsync(cancellationToken);
-        
+
         /// <summary>
         /// Closes the underlying transport.
         /// </summary>
@@ -235,7 +235,7 @@ namespace Lime.Protocol.Network
                 _receiverChannel.StopAsync(cts.Token),
                 _senderChannel.StopAsync(cts.Token));
         }
-        
+
         /// <summary>
         /// Cancels the token that is associated to the channel send and receive tasks.
         /// </summary>
@@ -257,7 +257,7 @@ namespace Lime.Protocol.Network
                 Trace.TraceError("[ChannelBase] Unhandled exception in the Transport_Closing handler: {0}", ex);
             }
         }
-        
+
         private static void OnStateChanged<T>(IEnumerable<IChannelModule<T>> modules, SessionState state) where T : Envelope, new()
         {
             foreach (var module in modules.ToList())
@@ -266,11 +266,21 @@ namespace Lime.Protocol.Network
             }
         }
 
-        private Task HandleConsumerExceptionAsync(Exception exception)=> HandleExceptionAsync(exception, ConsumerException);
+        private async Task HandleConsumerExceptionAsync(Exception exception) => await HandleExceptionAndCloseAsync(exception, ConsumerException);
 
-        private Task HandleSenderExceptionAsync(Exception exception) => HandleExceptionAsync(exception, SenderException);
-        
-        private async Task HandleExceptionAsync(Exception exception, EventHandler<ExceptionEventArgs> handler)
+        private async Task HandleSenderExceptionAsync(Exception exception)
+        {
+            if (exception is EnvelopeTooLargeException)
+            {
+                await RaiseExceptionHandlerAsync(SenderException, exception).ConfigureAwait(false);
+            }
+            else
+            {
+                await HandleExceptionAndCloseAsync(exception, SenderException);
+            }
+        }
+
+        private async Task HandleExceptionAndCloseAsync(Exception exception, EventHandler<ExceptionEventArgs> handler)
         {
             await RaiseExceptionHandlerAsync(handler, exception).ConfigureAwait(false);
             await CloseTransportAsync().ConfigureAwait(false);
@@ -313,7 +323,7 @@ namespace Lime.Protocol.Network
                 _receiverChannel.Dispose();
                 _senderChannel.Dispose();
                 Transport.DisposeIfDisposable();
-                _remotePingChannelModule?.Dispose();;
+                _remotePingChannelModule?.Dispose(); ;
             }
         }
     }

--- a/src/Lime.Protocol/Network/EnvelopeTooLargeException.cs
+++ b/src/Lime.Protocol/Network/EnvelopeTooLargeException.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Lime.Protocol.Network
+{
+    public class EnvelopeTooLargeException : Exception
+    {
+        public EnvelopeTooLargeException(string message) 
+            : base(message)
+        {
+        }
+
+        public EnvelopeTooLargeException(string message, Exception innerException) 
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/Lime.Transport.Tcp/TcpTransport.cs
+++ b/src/Lime.Transport.Tcp/TcpTransport.cs
@@ -41,10 +41,11 @@ namespace Lime.Transport.Tcp
         private readonly X509Certificate2 _serverCertificate;
         private readonly X509Certificate2 _clientCertificate;
         private readonly JsonBuffer _jsonBuffer;
+        private readonly int _maxBufferSize;
+        private readonly ArrayPool<byte> _arrayPool;
 
         private Stream _stream;
         private string _hostName;
-        private readonly ArrayPool<byte> _arrayPool;
         private bool _disposed;
 
         /// <summary>
@@ -177,6 +178,7 @@ namespace Lime.Transport.Tcp
             _traceWriter = traceWriter;
             _serverCertificateValidationCallback = serverCertificateValidationCallback ?? ValidateServerCertificate;
             _clientCertificateValidationCallback = clientCertificateValidationCallback ?? ValidateClientCertificate;
+            _maxBufferSize = maxBufferSize;
 
             _jsonBuffer = new JsonBuffer(bufferSize, maxBufferSize, _arrayPool);
             _optionsSemaphore = new SemaphoreSlim(1);
@@ -188,7 +190,6 @@ namespace Lime.Transport.Tcp
         /// <param name="envelope">Envelope to be transported</param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        /// <exception cref="System.NotImplementedException"></exception>
         public override async Task SendAsync(Envelope envelope, CancellationToken cancellationToken)
         {
             if (envelope == null) throw new ArgumentNullException(nameof(envelope));
@@ -196,6 +197,14 @@ namespace Lime.Transport.Tcp
             if (!_stream.CanWrite) throw new InvalidOperationException("Invalid stream state");
 
             var serializedEnvelope = _envelopeSerializer.Serialize(envelope);
+
+            if (serializedEnvelope.Length > _maxBufferSize)
+            {
+                // Prevent sending an envelope that could potentially make the receiver side drop the connection,
+                // since most probably it's _maxBufferSize has the same value used by the sender side
+                await TraceAsync($"EnvelopeTooLarge (size of {serializedEnvelope.Length}): {serializedEnvelope}", DataOperation.Error).ConfigureAwait(false);
+                throw new EnvelopeTooLargeException($"Envelope type {envelope.GetType().Name} with id {envelope.Id} and size {serializedEnvelope.Length} will probably exceed the maximum size supported by a receiver (the value for this instance is {_maxBufferSize})");
+            }
 
             await TraceAsync(serializedEnvelope, DataOperation.Send).ConfigureAwait(false);
             

--- a/src/Lime.Transport.Tcp/TcpTransport.cs
+++ b/src/Lime.Transport.Tcp/TcpTransport.cs
@@ -204,7 +204,7 @@ namespace Lime.Transport.Tcp
                 // Prevent sending an envelope that could potentially make the receiver side drop the connection,
                 // since most probably it's _maxBufferSize has the same value used by the sender side
                 await TraceAsync($"EnvelopeTooLarge (size of {envelopeByteCount}): {serializedEnvelope}", DataOperation.Error).ConfigureAwait(false);
-                throw new EnvelopeTooLargeException($"Envelope type {envelope.GetType().Name} with id {envelope.Id} and size {envelopeByteCount} will probably exceed the maximum size supported by a receiver (the value for this instance is {_maxBufferSize})");
+                throw new EnvelopeTooLargeException($"Envelope NOT sent: {envelope.GetType().Name} with id {envelope.Id} and size {envelopeByteCount} will probably exceed the maximum size supported by a receiver (the local value is {_maxBufferSize})");
             }
 
             await TraceAsync(serializedEnvelope, DataOperation.Send).ConfigureAwait(false);


### PR DESCRIPTION
If a channel sends a envelope above MaxBufferSize, this will make the receiver channel throw BufferOverflowException and close the channel.

Instead, let's prevent that such large payload could be sent on the first place. I suggest to throw a new EnvelopeTooLargeException on such cases, and this specific exception won't cause a connection closing, but still log the issue