### PR TITLE
Remove some async optimizations; Add a check for cancelled CTs

### DIFF
--- a/src/Lime.Protocol/Client/MultiplexerClientChannel.cs
+++ b/src/Lime.Protocol/Client/MultiplexerClientChannel.cs
@@ -133,14 +133,14 @@ namespace Lime.Protocol.Client
             _semaphore = new SemaphoreSlim(1, 1);
         }
 
-        public Task SendMessageAsync(Message message, CancellationToken cancellationToken)
-            => SendToBufferAsync(message, cancellationToken);
+        public async Task SendMessageAsync(Message message, CancellationToken cancellationToken)
+            => await SendToBufferAsync(message, cancellationToken);
 
-        public Task SendNotificationAsync(Notification notification, CancellationToken cancellationToken)
-            => SendToBufferAsync(notification, cancellationToken);
+        public async Task SendNotificationAsync(Notification notification, CancellationToken cancellationToken)
+            => await SendToBufferAsync(notification, cancellationToken);
 
-        public Task SendCommandAsync(Command command, CancellationToken cancellationToken)
-            => SendToBufferAsync(command, cancellationToken);
+        public async Task SendCommandAsync(Command command, CancellationToken cancellationToken)
+            => await SendToBufferAsync(command, cancellationToken);
 
         public async Task<Message> ReceiveMessageAsync(CancellationToken cancellationToken)
         {

--- a/src/Lime.Protocol/Client/OnDemandClientChannel.cs
+++ b/src/Lime.Protocol/Client/OnDemandClientChannel.cs
@@ -51,9 +51,9 @@ namespace Lime.Protocol.Client
         /// <param name="command"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public Task SendCommandAsync(Command command, CancellationToken cancellationToken)
+        public async Task SendCommandAsync(Command command, CancellationToken cancellationToken)
         {
-            return SendAsync(command, cancellationToken, (channel, envelope) => channel.SendCommandAsync(envelope, cancellationToken));
+            await SendAsync(command, cancellationToken, (channel, envelope) => channel.SendCommandAsync(envelope, cancellationToken));
         }
 
         /// <summary>
@@ -107,9 +107,9 @@ namespace Lime.Protocol.Client
         /// <param name="message"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public Task SendMessageAsync(Message message, CancellationToken cancellationToken)
+        public async Task SendMessageAsync(Message message, CancellationToken cancellationToken)
         {
-            return SendAsync(message, cancellationToken, (channel, envelope) => channel.SendMessageAsync(envelope, cancellationToken));
+            await SendAsync(message, cancellationToken, (channel, envelope) => channel.SendMessageAsync(envelope, cancellationToken));
         }
 
         /// <summary>
@@ -128,9 +128,9 @@ namespace Lime.Protocol.Client
         /// <param name="notification"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public Task SendNotificationAsync(Notification notification, CancellationToken cancellationToken)
+        public async Task SendNotificationAsync(Notification notification, CancellationToken cancellationToken)
         {
-            return SendAsync(notification, cancellationToken, (channel, envelope) => channel.SendNotificationAsync(envelope, cancellationToken));
+            await SendAsync(notification, cancellationToken, (channel, envelope) => channel.SendNotificationAsync(envelope, cancellationToken));
         }
 
         /// <summary>

--- a/src/Lime.Protocol/Network/ChannelCommandProcessor.cs
+++ b/src/Lime.Protocol/Network/ChannelCommandProcessor.cs
@@ -21,10 +21,7 @@ namespace Lime.Protocol.Network
         
         public async Task<Command> ProcessCommandAsync(ICommandSenderChannel commandSenderChannel, Command requestCommand, CancellationToken cancellationToken)
         {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                throw new TaskCanceledException();
-            }
+            cancellationToken.ThrowIfCancellationRequested();
 
             if (commandSenderChannel == null) throw new ArgumentNullException(nameof(commandSenderChannel));
             if (requestCommand == null) throw new ArgumentNullException(nameof(requestCommand));

--- a/src/Lime.Protocol/Network/ChannelCommandProcessor.cs
+++ b/src/Lime.Protocol/Network/ChannelCommandProcessor.cs
@@ -21,6 +21,11 @@ namespace Lime.Protocol.Network
         
         public async Task<Command> ProcessCommandAsync(ICommandSenderChannel commandSenderChannel, Command requestCommand, CancellationToken cancellationToken)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                throw new TaskCanceledException();
+            }
+
             if (commandSenderChannel == null) throw new ArgumentNullException(nameof(commandSenderChannel));
             if (requestCommand == null) throw new ArgumentNullException(nameof(requestCommand));
             if (requestCommand.Status != CommandStatus.Pending)

--- a/src/Lime.Protocol/Network/SenderChannel.cs
+++ b/src/Lime.Protocol/Network/SenderChannel.cs
@@ -54,14 +54,14 @@ namespace Lime.Protocol.Network
             _envelopeBuffer = ChannelUtil.CreateForCapacity<Envelope>(envelopeBufferSize, true, false);
         }
 
-        public Task SendMessageAsync(Message message, CancellationToken cancellationToken)
-            => SendToBufferAsync(message, _messageModules, cancellationToken);
+        public async Task SendMessageAsync(Message message, CancellationToken cancellationToken)
+            => await SendToBufferAsync(message, _messageModules, cancellationToken);
 
-        public Task SendNotificationAsync(Notification notification, CancellationToken cancellationToken)
-            => SendToBufferAsync(notification, _notificationModules, cancellationToken);
+        public async Task SendNotificationAsync(Notification notification, CancellationToken cancellationToken)
+            => await SendToBufferAsync(notification, _notificationModules, cancellationToken);
 
-        public Task SendCommandAsync(Command command, CancellationToken cancellationToken)
-            => SendToBufferAsync(command, _commandModules, cancellationToken);
+        public async Task SendCommandAsync(Command command, CancellationToken cancellationToken)
+            => await SendToBufferAsync(command, _commandModules, cancellationToken);
 
         public async Task SendSessionAsync(Session session, CancellationToken cancellationToken)
         {


### PR DESCRIPTION
On analyzing an issue with Luiz Guilherme, I noticed how a TaskCanceledException was being thrown later than it could've and also how parts of the stack trace were missing. 

This fixes both by 1) checking earlier for cancellation request and throwing a TCE in that case, instead of letting the code uselessly running until the late check (which, in the case of `MultiplexerClientChannel`, would be only at `SendToBufferAsync`, at a call to `System.Threading.Tasks.Dataflow.BufferBlock.SendAsync`, and 2) introducing the async keyword on methods that didnt have.