### PR TITLE
Allow TLS 1.1 and TLS 1.2 on Tcp transports

### DIFF
--- a/src/Lime.Transport.Tcp/PipeTcpTransport.cs
+++ b/src/Lime.Transport.Tcp/PipeTcpTransport.cs
@@ -268,7 +268,7 @@ namespace Lime.Transport.Tcp
                                 .AuthenticateAsServerAsync(
                                     _serverCertificate,
                                     true,
-                                    SslProtocols.Tls,
+                                    SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12,
                                     false)
                                 .WithCancellation(cancellationToken)
                                 .ConfigureAwait(false);
@@ -297,7 +297,7 @@ namespace Lime.Transport.Tcp
                                 .AuthenticateAsClientAsync(
                                     _hostName,
                                     clientCertificates,
-                                    SslProtocols.Tls,
+                                    SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12,
                                     false)
                                 .WithCancellation(cancellationToken)
                                 .ConfigureAwait(false);

--- a/src/Lime.Transport.Tcp/TcpTransport.cs
+++ b/src/Lime.Transport.Tcp/TcpTransport.cs
@@ -348,7 +348,7 @@ namespace Lime.Transport.Tcp
                                 .AuthenticateAsServerAsync(
                                     _serverCertificate,
                                     true,
-                                    SslProtocols.Tls,
+                                    SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12,
                                     false)
                                 .WithCancellation(cancellationToken)
                                 .ConfigureAwait(false);
@@ -377,7 +377,7 @@ namespace Lime.Transport.Tcp
                                 .AuthenticateAsClientAsync(
                                     _hostName,
                                     clientCertificates,
-                                    SslProtocols.Tls,
+                                    SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12,
                                     false)
                                 .WithCancellation(cancellationToken)
                                 .ConfigureAwait(false);


### PR DESCRIPTION
TCP transports are accepting TLS 1.0 only at this time. 
Let's start migrating to TLS 1.2 only by accepting TLS 1.1 and 1.2 as well, as a first step.