### PR TITLE
handling too large exception at senderChannel

### DIFF
--- a/src/Lime.Protocol.UnitTests/Network/ChannelBaseTests.cs
+++ b/src/Lime.Protocol.UnitTests/Network/ChannelBaseTests.cs
@@ -324,13 +324,13 @@ namespace Lime.Protocol.UnitTests.Network
             var content = Dummy.CreateTextContent();
             var message = Dummy.CreateMessage(content);
             var target = GetTarget(SessionState.Established);
-
-            // Act
+            //setting up failure state.
             await target.SendMessageAndDelayAsync(message, CancellationToken.None);
 
-            // Assert - should resolve other messages
+            // Act
             Assert.DoesNotThrowAsync(() => target.SendMessageAndDelayAsync(message, CancellationToken.None), "The send buffer is complete");
 
+            // Assert - should resolve other messages
             Assert.IsTrue((target).IsEstablished());
             _transport.Verify(
                 t => t.SendAsync(

--- a/src/Lime.Protocol.UnitTests/Network/ChannelBaseTests.cs
+++ b/src/Lime.Protocol.UnitTests/Network/ChannelBaseTests.cs
@@ -331,7 +331,6 @@ namespace Lime.Protocol.UnitTests.Network
             Assert.DoesNotThrowAsync(() => target.SendMessageAndDelayAsync(message, CancellationToken.None), "The send buffer is complete");
 
             // Assert - should resolve other messages
-            Assert.IsTrue((target).IsEstablished());
             _transport.Verify(
                 t => t.SendAsync(
                     message,

--- a/src/Lime.Protocol/Network/SenderChannel.cs
+++ b/src/Lime.Protocol/Network/SenderChannel.cs
@@ -220,6 +220,12 @@ namespace Lime.Protocol.Network
 
                         await _transport.SendAsync(envelope, linkedCts.Token).ConfigureAwait(false);
                     }
+                    catch (EnvelopeTooLargeException ex)
+                    {
+                        /*This exception is handled since a sender should not close his channel 
+                        * if a client requests for a large envelope.*/
+                        RaiseSenderException(ex);
+                    }
                     catch (ChannelClosedException) 
                     {
                         break;
@@ -231,10 +237,6 @@ namespace Lime.Protocol.Network
                     catch (ObjectDisposedException) when (_isDisposing)
                     {
                         break;
-                    }
-                    catch (EnvelopeTooLargeException ex)
-                    {
-                        RaiseSenderException(ex);
                     }
                     catch (Exception ex)
                     {

--- a/src/Lime.Protocol/Network/SenderChannel.cs
+++ b/src/Lime.Protocol/Network/SenderChannel.cs
@@ -232,6 +232,10 @@ namespace Lime.Protocol.Network
                     {
                         break;
                     }
+                    catch (EnvelopeTooLargeException ex)
+                    {
+                        RaiseSenderException(ex);
+                    }
                     catch (Exception ex)
                     {
                         exception = ex;


### PR DESCRIPTION
SenderChannels are being cancelled after a EnvelopeTooLargeException. 