### PR TITLE
Fix the special characters bug when calling LimeUri's ctor

### DIFF
--- a/src/Lime.Protocol.UnitTests.Common/Dummy.cs
+++ b/src/Lime.Protocol.UnitTests.Common/Dummy.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using Lime.Protocol.Serialization;
 
 namespace Lime.Protocol.UnitTests
 {
@@ -13,7 +12,8 @@ namespace Lime.Protocol.UnitTests
     {
         private static readonly Random _random        = new Random();
         private static readonly string _chars         = "abcdefghijklmnopqrstuvwxyz0123456789";
-        private static readonly string _extendedChars = _chars + "!@#$%¨&*()_+-=\"'{}[],.;/<>:?^~\\áéíóúàèìòùºç ";
+        private static readonly string _specialChars  = "!@#$%¨&*()_+-=\"'{}[],.;/<>:?^~\\áéíóúàèìòùºç ";
+        private static readonly string _extendedChars = _chars + _specialChars;
 
         public static int CreateRandomInt(int maxValue)
         {
@@ -23,6 +23,11 @@ namespace Lime.Protocol.UnitTests
         public static string CreateRandomString(int size)
         {
             return CreateRandomString(size, _chars);
+        }
+
+        public static string CreateRandomStringSpecial(int size)
+        {
+            return CreateRandomString(size, _specialChars);
         }
 
         public static string CreateRandomStringExtended(int size)

--- a/src/Lime.Protocol.UnitTests/LimeUriTests.cs
+++ b/src/Lime.Protocol.UnitTests/LimeUriTests.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using Shouldly;
 using System;
+using System.Net;
 
 namespace Lime.Protocol.UnitTests
 {
@@ -25,6 +26,19 @@ namespace Lime.Protocol.UnitTests
             var identity = Dummy.CreateIdentity();
             var resourceName = Dummy.CreateRandomString(10);
             var absolutePath = string.Format("{0}://{1}/{2}", LimeUri.LIME_URI_SCHEME, identity, resourceName);
+            var actual = LimeUri.Parse(absolutePath);
+
+            actual.Path.ShouldNotBe(null);
+            actual.Path.ShouldBe(absolutePath);
+            actual.IsRelative.ShouldBe(false);
+        }
+
+        [Test]
+        public void Parse_ValidAbsoluteSpecialCharactersString_ReturnsInstance()
+        {
+            var identity = Dummy.CreateIdentity();
+            var resourceNameWithSpace = $"{Dummy.CreateRandomStringSpecial(5)} {Dummy.CreateRandomStringSpecial(5)}";
+            var absolutePath = string.Format("{0}://{1}/{2}", LimeUri.LIME_URI_SCHEME, identity, WebUtility.UrlEncode(resourceNameWithSpace));
             var actual = LimeUri.Parse(absolutePath);
 
             actual.Path.ShouldNotBe(null);

--- a/src/Lime.Protocol.UnitTests/LimeUriTests.cs
+++ b/src/Lime.Protocol.UnitTests/LimeUriTests.cs
@@ -34,7 +34,7 @@ namespace Lime.Protocol.UnitTests
         }
 
         [Test]
-        public void Parse_ValidAbsoluteSpecialCharactersString_ReturnsInstance()
+        public void Parse_ValidAbsoluteSpecialCharactersStringContainingSpace_ReturnsInstance()
         {
             var identity = Dummy.CreateIdentity();
             var resourceNameWithSpace = $"{Dummy.CreateRandomStringSpecial(5)} {Dummy.CreateRandomStringSpecial(5)}";

--- a/src/Lime.Protocol/LimeUri.cs
+++ b/src/Lime.Protocol/LimeUri.cs
@@ -37,7 +37,7 @@ namespace Lime.Protocol
                 // TODO: This 'if' statement is only necessary while the related issue is not fixed
                 // Issue: https://github.com/dotnet/runtime/issues/21626
                 if (Uri.TryCreate(uriPath, UriKind.Absolute, out var receivedUri) &&
-                    ReceivedUriPathIsEncoded(receivedUri) &&
+                    ReceivedUriPathIsEncoded(uriPath) &&
                     Uri.IsWellFormedUriString($"{receivedUri.Scheme}://{receivedUri.UserInfo}@{receivedUri.Host}", UriKind.Absolute) &&
                     Uri.IsWellFormedUriString(receivedUri.PathAndQuery + receivedUri.Fragment, UriKind.Relative))
                 {
@@ -158,7 +158,7 @@ namespace Lime.Protocol
         public static implicit operator string(LimeUri limeUri) => limeUri?.ToString();
 
         // TODO: Remove this method once the 'if' statement on the ctor is removed
-        private bool ReceivedUriPathIsEncoded(Uri receivedUri)
-            => WebUtility.UrlDecode(receivedUri.OriginalString) != receivedUri.OriginalString;
+        private bool ReceivedUriPathIsEncoded(string uri)
+            => WebUtility.UrlDecode(uri) != uri;
     }
 }

--- a/src/Lime.Protocol/LimeUri.cs
+++ b/src/Lime.Protocol/LimeUri.cs
@@ -27,7 +27,7 @@ namespace Lime.Protocol
             if (Uri.IsWellFormedUriString(uriPath, UriKind.Absolute))
             {
                 _absoluteUri = new Uri(uriPath);
-                ValidateAbsoluteUri(_absoluteUri);
+                ValidatLimeScheme(_absoluteUri);
             }
             else if (!Uri.IsWellFormedUriString(uriPath, UriKind.Relative))
             {
@@ -39,7 +39,7 @@ namespace Lime.Protocol
                     Uri.IsWellFormedUriString(receivedUri.PathAndQuery + receivedUri.Fragment, UriKind.Relative))
                 {
                     _absoluteUri = new Uri(uriPath);
-                    ValidateAbsoluteUri(_absoluteUri);
+                    ValidatLimeScheme(_absoluteUri);
                 }
                 else
                 {
@@ -155,7 +155,7 @@ namespace Lime.Protocol
         private bool ReceivedUriPathIsEncoded(string uri)
             => WebUtility.UrlDecode(uri) != uri;
 
-        private void ValidateAbsoluteUri(Uri absoluteUri)
+        private void ValidatLimeScheme(Uri absoluteUri)
         {
             if (!absoluteUri.Scheme.Equals(LIME_URI_SCHEME))
             {

--- a/src/Lime.Protocol/LimeUri.cs
+++ b/src/Lime.Protocol/LimeUri.cs
@@ -27,10 +27,7 @@ namespace Lime.Protocol
             if (Uri.IsWellFormedUriString(uriPath, UriKind.Absolute))
             {
                 _absoluteUri = new Uri(uriPath);
-                if (!_absoluteUri.Scheme.Equals(LIME_URI_SCHEME))
-                {
-                    throw new ArgumentException($"Invalid URI scheme. Expected is '{LIME_URI_SCHEME}'");
-                }
+                ValidateAbsoluteUri(_absoluteUri);
             }
             else if (!Uri.IsWellFormedUriString(uriPath, UriKind.Relative))
             {
@@ -41,11 +38,8 @@ namespace Lime.Protocol
                     Uri.IsWellFormedUriString($"{receivedUri.Scheme}://{receivedUri.UserInfo}@{receivedUri.Host}", UriKind.Absolute) &&
                     Uri.IsWellFormedUriString(receivedUri.PathAndQuery + receivedUri.Fragment, UriKind.Relative))
                 {
-                    _absoluteUri = receivedUri;
-                    if (!_absoluteUri.Scheme.Equals(LIME_URI_SCHEME))
-                    {
-                        throw new ArgumentException($"Invalid URI scheme. Expected is '{LIME_URI_SCHEME}'");
-                    }
+                    _absoluteUri = new Uri(uriPath);
+                    ValidateAbsoluteUri(_absoluteUri);
                 }
                 else
                 {
@@ -160,5 +154,13 @@ namespace Lime.Protocol
         // TODO: Remove this method once the 'if' statement on the ctor is removed
         private bool ReceivedUriPathIsEncoded(string uri)
             => WebUtility.UrlDecode(uri) != uri;
+
+        private void ValidateAbsoluteUri(Uri absoluteUri)
+        {
+            if (!absoluteUri.Scheme.Equals(LIME_URI_SCHEME))
+            {
+                throw new ArgumentException($"Invalid URI scheme. Expected is '{LIME_URI_SCHEME}'");
+            }
+        }
     }
 }

--- a/src/Lime.Protocol/LimeUri.cs
+++ b/src/Lime.Protocol/LimeUri.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net;
 
 namespace Lime.Protocol
 {
@@ -33,9 +34,24 @@ namespace Lime.Protocol
             }
             else if (!Uri.IsWellFormedUriString(uriPath, UriKind.Relative))
             {
-                throw new ArgumentException("Invalid URI format");
+                // TODO: This 'if' statement is only necessary while the related issue is not fixed
+                // Issue: https://github.com/dotnet/runtime/issues/21626
+                if (Uri.TryCreate(uriPath, UriKind.Absolute, out var receivedUri) &&
+                    ReceivedUriPathIsEncoded(receivedUri) &&
+                    Uri.IsWellFormedUriString($"{receivedUri.Scheme}://{receivedUri.UserInfo}@{receivedUri.Host}", UriKind.Absolute) &&
+                    Uri.IsWellFormedUriString(receivedUri.PathAndQuery + receivedUri.Fragment, UriKind.Relative))
+                {
+                    _absoluteUri = receivedUri;
+                    if (!_absoluteUri.Scheme.Equals(LIME_URI_SCHEME))
+                    {
+                        throw new ArgumentException($"Invalid URI scheme. Expected is '{LIME_URI_SCHEME}'");
+                    }
+                }
+                else
+                {
+                    throw new ArgumentException("Invalid URI format");
+                }
             }
-
             Path = uriPath.TrimEnd('/');
         }
 
@@ -140,5 +156,9 @@ namespace Lime.Protocol
         public static implicit operator LimeUri(string value) => value == null ? null : Parse(value);
         
         public static implicit operator string(LimeUri limeUri) => limeUri?.ToString();
+
+        // TODO: Remove this method once the 'if' statement on the ctor is removed
+        private bool ReceivedUriPathIsEncoded(Uri receivedUri)
+            => WebUtility.UrlDecode(receivedUri.OriginalString) != receivedUri.OriginalString;
     }
 }


### PR DESCRIPTION
This P.R aims to fix the existing bug when calling `LimeUri`´s constructor.

**The bug**

When trying to create a new `LimeUri` with a string containing both a space and a special character (e.g.: "Test é", which encoded becomes "Test%20%C3%A9") we currently get the exception "Invalid URI format".
Although this string is valid, there currently is an issue regarding Uri verification in dotnet, specifically the method `Uri.IsWellFormedUriString()`. The issue can be found [here](https://github.com/dotnet/runtime/issues/21626).

Until that issue is resolved, we found a way around it, which is to be later removed from our code.

**A way around it**

The implemented change is specific to the constructor in `LimeUri` (and also a tiny little private method...but we'll get to that later).

Prior to this submission, the constructor used to validate the received Uri as such:

```
if (Uri.IsWellFormedUriString(uriPath, UriKind.Absolute))
{
    _absoluteUri = new Uri(uriPath);
    if (!_absoluteUri.Scheme.Equals(LIME_URI_SCHEME))
    {
        throw new ArgumentException($"Invalid URI scheme. Expected is '{LIME_URI_SCHEME}'");
    }
}
else if (!Uri.IsWellFormedUriString(uriPath, UriKind.Relative))
{
    throw new ArgumentException("Invalid URI format");
}
```

We first noticed that there isn't a problem when checking for `Uri.IsWellFormedUriString("/something/Test%20%C3%A9", UriKind.Relative)` and that the problem arises when checking for `Uri.IsWellFormedUriString("lime://name@domain/something/Test%20%C3%A9", UriKind.Absolute)` and `Uri.IsWellFormedUriString("lime://name@domain/something/Test%20%C3%A9", UriKind.Relative)`.
That being said we applied the following:

```
if (Uri.IsWellFormedUriString(uriPath, UriKind.Absolute))
{
    _absoluteUri = new Uri(uriPath);
     if (!_absoluteUri.Scheme.Equals(LIME_URI_SCHEME))
     {
         throw new ArgumentException($"Invalid URI scheme. Expected is '{LIME_URI_SCHEME}'");
     }
}
else if (!Uri.IsWellFormedUriString(uriPath, UriKind.Relative))
{
    if (Uri.TryCreate(uriPath, UriKind.Absolute, out var receivedUri) &&
        ReceivedUriPathIsEncoded(receivedUri) &&
        Uri.IsWellFormedUriString($"{receivedUri.Scheme}://{receivedUri.UserInfo}@{receivedUri.Host}", UriKind.Absolute) &&
        Uri.IsWellFormedUriString(receivedUri.PathAndQuery + receivedUri.Fragment, UriKind.Relative))
    {
        _absoluteUri = receivedUri;
        if (!_absoluteUri.Scheme.Equals(LIME_URI_SCHEME))
        {
            throw new ArgumentException($"Invalid URI scheme. Expected is '{LIME_URI_SCHEME}'");
        }
    }
    else
    {
        throw new ArgumentException("Invalid URI format");
    }
}
```

**Reasoning Behind Change**

First and foremost I think it is worth noting that the above code guarantees that we are not modifying behavior for Uris that were previously seen as valid Uris. Now, onto the more detailed explanation:

Imagine we have the following Uri string: "lime://name@domain/something/Test%20%C3%A9", which would previously throw an Exception.

The idea behind the code that was introduced is to check, separately, for the validity of "lime://name@domain" as `UriKind.Absolute` and "something/Test%20%C3%A9" as `UriKind.Relative`. If both are valid, then we assume that the received Uri is valid.

To facilitate the handling of the received Uri (since it is received as a `string`), we first call `Uri.TryCreate(uriPath, UriKind.Absolute, out var receivedUri)`. If we are unable to create an Uri from the received `uriPath`, then we also take it as being an invalid Uri.

All´s good except for the fact that by calling `Uri.TryCreate(uriPath, UriKind.Absolute, out var receivedUri)` and then handling `receivedUri`, we are in fact introducing a possible bug, in which a received Uri that is not encoded (and should have been) such as "this is a test", gets encoded when calling `Uri.TryCreate()`. In this case we would be accepting a Uri string that wasn't previously accepted.

To solve for this scenario, we explicit check for Uri encoding, by calling `ReceivedUriPathIsEncoded(receivedUri)` (that tiny little private method I mentioned earlier):

```
private bool ReceivedUriPathIsEncoded(Uri receivedUri)
    => WebUtility.UrlDecode(receivedUri.OriginalString) != receivedUri.OriginalString;
```

**Other changes in this P.R**

All the other changes included in this P.R. are related to unit tests.

A test was created to explicitly validate the creation of a `LimeUri` with a Uri containing both a special character and a space. To do so there was the need for a couple of small changes in the `Dummy` class as well as (obviously) in the `LimeUriTests` class