### PR TITLE
Create Variable profiles on Lime Test Console

### DIFF
--- a/src/Lime.Client.TestConsole/FileUtil.cs
+++ b/src/Lime.Client.TestConsole/FileUtil.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace Lime.Client.TestConsole
 {
@@ -29,7 +30,7 @@ namespace Lime.Client.TestConsole
             }
 
             fileName = appDataFileName;
-            
+
             using (var fileStream = File.Open(fileName, FileMode.OpenOrCreate, FileAccess.Read))
             {
                 using (var streamReader = new StreamReader(fileStream))
@@ -47,10 +48,45 @@ namespace Lime.Client.TestConsole
             }
         }
 
+        public static T GetFileContent<T>(string fileName)
+        {
+            var appDataFileName = GetAppDataFileName(fileName);
+            T fileContent;
+
+            if (!File.Exists(appDataFileName))
+            {
+                if (File.Exists(fileName))
+                {
+                    File.Copy(fileName, appDataFileName);
+                }
+                else
+                {
+                    File.Create(appDataFileName).Close();
+                }
+            }
+
+            fileName = appDataFileName;
+
+            using (StreamReader file = File.OpenText(fileName))
+            {
+                JsonSerializer serializer = new JsonSerializer();
+                fileContent = (T)serializer.Deserialize(file, typeof(T));
+            }
+
+            return fileContent;
+        }
+
         public static void SaveFile(IEnumerable<string[]> content, string fileName, char separator)
         {
             fileName = GetAppDataFileName(fileName);
             File.WriteAllLines(fileName, content.Select(s => string.Join(separator.ToString(CultureInfo.InvariantCulture), s)));
+        }
+
+        public static void SaveFile(object content, string fileName)
+        {
+            fileName = GetAppDataFileName(fileName);
+            var stringContent = JsonConvert.SerializeObject(content);
+            File.WriteAllText(fileName, stringContent);
         }
 
         private static string GetAppDataFileName(string fileName)

--- a/src/Lime.Client.TestConsole/Lime.Client.TestConsole.csproj
+++ b/src/Lime.Client.TestConsole/Lime.Client.TestConsole.csproj
@@ -208,6 +208,7 @@
     <Compile Include="ViewModels\EnvelopeViewModel.cs" />
     <Compile Include="ViewModels\MacroViewModel.cs" />
     <Compile Include="ViewModels\MainViewModel.cs" />
+    <Compile Include="ViewModels\ProfileViewModel.cs" />
     <Compile Include="ViewModels\SessionViewModel.cs" />
     <Compile Include="ViewModels\StatusMessageViewModel.cs" />
     <Compile Include="ViewModels\TemplateViewModel.cs" />

--- a/src/Lime.Client.TestConsole/MainWindow.xaml
+++ b/src/Lime.Client.TestConsole/MainWindow.xaml
@@ -9,7 +9,7 @@
         mc:Ignorable="d" 
         DataContext="{StaticResource MainViewModel}"
         d:DataContext="{d:DesignData /DesignData/MainDesignData.xaml}"   
-        Title="{Binding Title}" Height="600" Width="800" Icon="lime.ico">
+        Title="{Binding Title}" Height="800" Width="1200" Icon="lime.ico">
    
     <i:Interaction.Triggers>
         <i:EventTrigger EventName="Closing">

--- a/src/Lime.Client.TestConsole/MainWindow.xaml
+++ b/src/Lime.Client.TestConsole/MainWindow.xaml
@@ -9,7 +9,7 @@
         mc:Ignorable="d" 
         DataContext="{StaticResource MainViewModel}"
         d:DataContext="{d:DesignData /DesignData/MainDesignData.xaml}"   
-        Title="{Binding Title}" Height="800" Width="1200" Icon="lime.ico">
+        Title="{Binding Title}" Height="900" Width="1350" Icon="lime.ico">
    
     <i:Interaction.Triggers>
         <i:EventTrigger EventName="Closing">

--- a/src/Lime.Client.TestConsole/ViewModels/ProfileViewModel.cs
+++ b/src/Lime.Client.TestConsole/ViewModels/ProfileViewModel.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using GalaSoft.MvvmLight;
+
+namespace Lime.Client.TestConsole.ViewModels
+{
+    public class ProfileViewModel : ViewModelBase
+    {
+        private string _name;
+
+        public string Name
+        {
+            get { return _name; }
+            set
+            {
+                _name = value;
+                RaisePropertyChanged(() => Name);
+            }
+        }
+
+        private IDictionary<string, string> _jsonValues;
+
+        public IDictionary<string, string> JsonValues
+        {
+            get { return _jsonValues; }
+            set
+            {
+                _jsonValues = value;
+                RaisePropertyChanged(() => JsonValues);
+            }
+        }
+    }
+}

--- a/src/Lime.Client.TestConsole/ViewModels/SessionViewModel.cs
+++ b/src/Lime.Client.TestConsole/ViewModels/SessionViewModel.cs
@@ -57,7 +57,7 @@ namespace Lime.Client.TestConsole.ViewModels
             ParseCommand = new RelayCommand(Parse, CanParse);
             LoadProfileCommand = new RelayCommand(LoadProfile);
             SaveProfileCommand = new RelayCommand(SaveProfile);
-            DeleteElementProfileCommand = new RelayCommand(DeleteProfile);
+            DeleteElementProfileCommand = new RelayCommand(DeleteProfile, CanDeleteProfile);
 
             // Defaults
             DarkMode = false;
@@ -569,6 +569,18 @@ namespace Lime.Client.TestConsole.ViewModels
             }
         }
 
+        private int _selectedProfileIndex = -1;
+
+        public int SelectedProfileIndex
+        {
+            get { return _selectedProfileIndex; }
+            set
+            {
+                _selectedProfileIndex = value;
+                RaisePropertyChanged(() => SelectedProfileIndex);
+            }
+        }
+
         public AsyncCommand OpenTransportCommand { get; private set; }
 
         private async Task OpenTransportAsync()
@@ -893,6 +905,9 @@ namespace Lime.Client.TestConsole.ViewModels
 
         private void LoadProfile()
         {
+            if (SelectedProfile == null)
+                return;
+
             Variables = new ObservableCollectionEx<VariableViewModel>();
 
             foreach (var item in SelectedProfile.JsonValues)
@@ -926,6 +941,10 @@ namespace Lime.Client.TestConsole.ViewModels
                 existingProfile.JsonValues = variablesDictionary;
 
                 Profiles[existingIndex] = existingProfile;
+
+                SelectedProfileIndex = existingIndex;
+                AddStatusMessage($"Changes applided to profile '{ProfileName}' sucessfully!");
+
                 return;
             }
 
@@ -934,6 +953,8 @@ namespace Lime.Client.TestConsole.ViewModels
                 Name = ProfileName,
                 JsonValues = variablesDictionary
             });
+
+            AddStatusMessage($"Profile '{ProfileName}' created successfully!");
         }
 
         public RelayCommand DeleteElementProfileCommand { get; private set; }
@@ -941,7 +962,10 @@ namespace Lime.Client.TestConsole.ViewModels
         private void DeleteProfile()
         {
             Profiles.Remove(SelectedProfile);
+            ProfileName = string.Empty;
         }
+
+        private bool CanDeleteProfile() => SelectedProfile != null;
 
         private void Execute(Action action)
         {
@@ -1068,7 +1092,7 @@ namespace Lime.Client.TestConsole.ViewModels
         {
             var content = FileUtil.GetFileContent<ObservableCollectionEx<ProfileViewModel>>(PROFILE_FILE_NAME);
 
-            if (content!=null)
+            if (content != null)
                 Profiles = content;
         }
 

--- a/src/Lime.Client.TestConsole/ViewModels/SessionViewModel.cs
+++ b/src/Lime.Client.TestConsole/ViewModels/SessionViewModel.cs
@@ -57,6 +57,7 @@ namespace Lime.Client.TestConsole.ViewModels
             ParseCommand = new RelayCommand(Parse, CanParse);
             LoadProfileCommand = new RelayCommand(LoadProfile);
             SaveProfileCommand = new RelayCommand(SaveProfile);
+            DeleteElementProfileCommand = new RelayCommand(DeleteProfile);
 
             // Defaults
             DarkMode = false;
@@ -935,6 +936,13 @@ namespace Lime.Client.TestConsole.ViewModels
                 Name = ProfileName,
                 JsonValues = variablesDictionary
             });
+        }
+
+        public RelayCommand DeleteElementProfileCommand { get; private set; }
+
+        private void DeleteProfile()
+        {
+            Profiles.Remove(SelectedProfile);
         }
 
         private void Execute(Action action)

--- a/src/Lime.Client.TestConsole/ViewModels/SessionViewModel.cs
+++ b/src/Lime.Client.TestConsole/ViewModels/SessionViewModel.cs
@@ -954,6 +954,8 @@ namespace Lime.Client.TestConsole.ViewModels
                 JsonValues = variablesDictionary
             });
 
+            SelectedProfileIndex = Profiles.Count - 1;
+
             AddStatusMessage($"Profile '{ProfileName}' created successfully!");
         }
 

--- a/src/Lime.Client.TestConsole/ViewModels/SessionViewModel.cs
+++ b/src/Lime.Client.TestConsole/ViewModels/SessionViewModel.cs
@@ -918,9 +918,7 @@ namespace Lime.Client.TestConsole.ViewModels
                 variablesDictionary.Add(item.Name, item.Value);
             }
 
-            var existingProfile = Profiles
-                                        .Where(p => p.Name.Equals(ProfileName, StringComparison.InvariantCultureIgnoreCase))
-                                        .FirstOrDefault();
+            var existingProfile = Profiles.FirstOrDefault(p => p.Name.Equals(ProfileName, StringComparison.InvariantCultureIgnoreCase));
 
             if (existingProfile != null)
             {
@@ -1070,7 +1068,8 @@ namespace Lime.Client.TestConsole.ViewModels
         {
             var content = FileUtil.GetFileContent<ObservableCollectionEx<ProfileViewModel>>(PROFILE_FILE_NAME);
 
-            Profiles = content;
+            if (content!=null)
+                Profiles = content;
         }
 
         private void LoadConfigurations()

--- a/src/Lime.Client.TestConsole/Views/DarkModeDictionary.xaml
+++ b/src/Lime.Client.TestConsole/Views/DarkModeDictionary.xaml
@@ -51,6 +51,13 @@ xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                 <Setter Property="Foreground" Value="White"></Setter>
                 <Setter Property="Background" Value="{DynamicResource DarkModeColor}"></Setter>
             </Style>
+            <Style TargetType="DataGridColumnHeader">
+                <Setter Property="Foreground" Value="White"></Setter>
+                <Setter Property="Background" Value="{DynamicResource DarkModeDataGridHeader}"></Setter>
+            </Style>
+            <Style TargetType="DataGrid">
+                <Setter Property="Background" Value="Transparent"></Setter>
+            </Style>
             <Style TargetType="StackPanel">
                 <Setter Property="Background" Value="Transparent"></Setter>
             </Style>
@@ -66,10 +73,87 @@ xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                 <Setter Property="Margin" Value="0,0,5,0" />
                 <Setter Property="Padding" Value="15,2" />
             </Style>
-            <Style TargetType="DataGridColumnHeader">
-                <Setter Property="Foreground" Value="White"></Setter>
-                <Setter Property="Background" Value="{DynamicResource DarkModeDataGridHeader}"></Setter>
-            </Style>
         </Style.Resources>
+    </Style>
+
+    <!--Scrollbar Thumbs-->
+    <Style x:Key="ScrollThumbs" TargetType="{x:Type Thumb}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type Thumb}">
+                    <Grid x:Name="Grid">
+                        <Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Width="Auto" Height="Auto" Fill="Transparent" />
+                        <Border x:Name="Rectangle1" CornerRadius="5" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Width="Auto" Height="Auto"  Background="{TemplateBinding Background}" />
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="Tag" Value="Horizontal">
+                            <Setter TargetName="Rectangle1" Property="Width" Value="Auto" />
+                            <Setter TargetName="Rectangle1" Property="Height" Value="7" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!--ScrollBars-->
+    <Style x:Key="{x:Type ScrollBar}" TargetType="{x:Type ScrollBar}">
+        <Setter Property="Stylus.IsFlicksEnabled" Value="false" />
+        <Setter Property="Foreground" Value="#8C8C8C" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Width" Value="8" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ScrollBar}">
+                    <Grid x:Name="GridRoot" Width="8" Background="{TemplateBinding Background}">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="0.00001*" />
+                        </Grid.RowDefinitions>
+
+                        <Track x:Name="PART_Track" Grid.Row="0" IsDirectionReversed="true" Focusable="false">
+                            <Track.Thumb>
+                                <Thumb x:Name="Thumb" Background="{TemplateBinding Foreground}" Style="{DynamicResource ScrollThumbs}" />
+                            </Track.Thumb>
+                            <Track.IncreaseRepeatButton>
+                                <RepeatButton x:Name="PageUp" Command="ScrollBar.PageDownCommand" Opacity="0" Focusable="false" />
+                            </Track.IncreaseRepeatButton>
+                            <Track.DecreaseRepeatButton>
+                                <RepeatButton x:Name="PageDown" Command="ScrollBar.PageUpCommand" Opacity="0" Focusable="false" />
+                            </Track.DecreaseRepeatButton>
+                        </Track>
+                    </Grid>
+
+                    <ControlTemplate.Triggers>
+                        <Trigger SourceName="Thumb" Property="IsMouseOver" Value="true">
+                            <Setter Value="{DynamicResource ButtonSelectBrush}" TargetName="Thumb" Property="Background" />
+                        </Trigger>
+                        <Trigger SourceName="Thumb" Property="IsDragging" Value="true">
+                            <Setter Value="{DynamicResource DarkBrush}" TargetName="Thumb" Property="Background" />
+                        </Trigger>
+
+                        <Trigger Property="IsEnabled" Value="false">
+                            <Setter TargetName="Thumb" Property="Visibility" Value="Collapsed" />
+                        </Trigger>
+                        <Trigger Property="Orientation" Value="Horizontal">
+                            <Setter TargetName="GridRoot" Property="LayoutTransform">
+                                <Setter.Value>
+                                    <RotateTransform Angle="-90" />
+                                </Setter.Value>
+                            </Setter>
+                            <Setter TargetName="PART_Track" Property="LayoutTransform">
+                                <Setter.Value>
+                                    <RotateTransform Angle="-90" />
+                                </Setter.Value>
+                            </Setter>
+                            <Setter Property="Width" Value="Auto" />
+                            <Setter Property="Height" Value="8" />
+                            <Setter TargetName="Thumb" Property="Tag" Value="Horizontal" />
+                            <Setter TargetName="PageDown" Property="Command" Value="ScrollBar.PageLeftCommand" />
+                            <Setter TargetName="PageUp" Property="Command" Value="ScrollBar.PageRightCommand" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 </ResourceDictionary>

--- a/src/Lime.Client.TestConsole/Views/DarkModeDictionary.xaml
+++ b/src/Lime.Client.TestConsole/Views/DarkModeDictionary.xaml
@@ -83,12 +83,12 @@ xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                 <ControlTemplate TargetType="{x:Type Thumb}">
                     <Grid x:Name="Grid">
                         <Rectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Width="Auto" Height="Auto" Fill="Transparent" />
-                        <Border x:Name="Rectangle1" CornerRadius="5" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Width="Auto" Height="Auto"  Background="{TemplateBinding Background}" />
+                        <Border x:Name="Rectangle1" CornerRadius="1" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Width="Auto" Height="Auto"  Background="{TemplateBinding Background}" />
                     </Grid>
                     <ControlTemplate.Triggers>
                         <Trigger Property="Tag" Value="Horizontal">
                             <Setter TargetName="Rectangle1" Property="Width" Value="Auto" />
-                            <Setter TargetName="Rectangle1" Property="Height" Value="7" />
+                            <Setter TargetName="Rectangle1" Property="Height" Value="Auto" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -101,13 +101,13 @@ xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         <Setter Property="Stylus.IsFlicksEnabled" Value="false" />
         <Setter Property="Foreground" Value="#8C8C8C" />
         <Setter Property="Background" Value="Transparent" />
-        <Setter Property="Width" Value="8" />
+        <Setter Property="Width" Value="10" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ScrollBar}">
-                    <Grid x:Name="GridRoot" Width="8" Background="{TemplateBinding Background}">
+                    <Grid x:Name="GridRoot" Margin="4,0,0,0" Width="11" Background="{TemplateBinding Background}">
                         <Grid.RowDefinitions>
-                            <RowDefinition Height="0.00001*" />
+                            <RowDefinition Height="*" />
                         </Grid.RowDefinitions>
 
                         <Track x:Name="PART_Track" Grid.Row="0" IsDirectionReversed="true" Focusable="false">
@@ -156,4 +156,5 @@ xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
             </Setter.Value>
         </Setter>
     </Style>
+
 </ResourceDictionary>

--- a/src/Lime.Client.TestConsole/Views/SessionView.xaml
+++ b/src/Lime.Client.TestConsole/Views/SessionView.xaml
@@ -168,9 +168,45 @@
                             <RowDefinition Height="200*" />
                             <RowDefinition Height="200*" />
                             <RowDefinition Height="200*" />
+                            <RowDefinition Height="200*" />
                         </Grid.RowDefinitions>
 
                         <Grid Grid.Row="0">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+
+                            <Label Grid.Row="0" Content="Variable Profiles" FontWeight="Bold" />
+                            <ListBox Grid.Row="1" ItemsSource="{Binding ProfilesView}" SelectedValue="{Binding SelectedProfile}">
+                                <i:Interaction.Triggers>
+                                    <i:EventTrigger EventName="MouseDoubleClick">
+                                        <i:InvokeCommandAction Command="{Binding LoadProfileCommand}" />
+                                    </i:EventTrigger>
+                                </i:Interaction.Triggers>
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding Name}" />
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                                <ListBox.GroupStyle>
+                                    <GroupStyle>
+                                        <GroupStyle.HeaderTemplate>
+                                            <DataTemplate>
+                                                <TextBlock FontWeight="Bold"  Text="{Binding Name}" />
+                                            </DataTemplate>
+                                        </GroupStyle.HeaderTemplate>
+                                    </GroupStyle>
+                                </ListBox.GroupStyle>
+                            </ListBox>
+                            <StackPanel Grid.Row="2" Margin="0,5" Orientation="Horizontal" HorizontalAlignment="Right">
+                                <xctk:WatermarkTextBox Text="{Binding ProfileName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,5,0" MinWidth="150" Watermark="Profile name"></xctk:WatermarkTextBox>
+                                <Button Content="Save Profile" Command="{Binding SaveProfileCommand}" />
+                            </StackPanel>
+                        </Grid>
+
+                        <Grid Grid.Row="1">
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition Height="*" />
@@ -187,7 +223,7 @@
                             </ScrollViewer>
                         </Grid>
 
-                        <Grid Grid.Row="1">
+                        <Grid Grid.Row="2">
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition Height="Auto" />
@@ -225,7 +261,7 @@
                             </StackPanel>
                         </Grid>
 
-                        <Grid Grid.Row="2">
+                        <Grid Grid.Row="3">
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition Height="*" />

--- a/src/Lime.Client.TestConsole/Views/SessionView.xaml
+++ b/src/Lime.Client.TestConsole/Views/SessionView.xaml
@@ -114,10 +114,10 @@
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
 
-                    <xctk:WatermarkTextBox FontFamily="Courier New"
+                    <xctk:WatermarkTextBox Margin="0,0,8,0" FontFamily="Courier New"
                                        Watermark="JSON input"
                                        TextWrapping="NoWrap"
-                                       VerticalScrollBarVisibility="Visible"
+                                       VerticalScrollBarVisibility="Auto"
                                        HorizontalScrollBarVisibility="Auto"
                                        AcceptsReturn="True"
                                        AcceptsTab="True"
@@ -200,10 +200,12 @@
                                     </GroupStyle>
                                 </ListBox.GroupStyle>
                             </ListBox>
+                            
                             <StackPanel Grid.Row="2" Margin="0,5" Orientation="Horizontal" HorizontalAlignment="Right">
-                                <xctk:WatermarkTextBox Text="{Binding ProfileName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,5,0" MinWidth="150" Watermark="Profile name"></xctk:WatermarkTextBox>
+                                <xctk:WatermarkTextBox Text="{Binding ProfileName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,5,0" MinWidth="125" Watermark="Profile name"></xctk:WatermarkTextBox>
                                 <Button Content="Save Profile" Command="{Binding SaveProfileCommand}" />
                             </StackPanel>
+                            
                         </Grid>
 
                         <Grid Grid.Row="1">
@@ -232,7 +234,7 @@
                             </Grid.RowDefinitions>
 
                             <Label Grid.Row="0" Content="Templates" FontWeight="Bold" />
-                            <xctk:WatermarkTextBox Watermark="Search templates" Grid.Row="1" Text="{Binding TemplatesFilter, UpdateSourceTrigger=PropertyChanged}" />
+                            <xctk:WatermarkTextBox Margin="0,0,0,5" Grid.Row="1" Watermark="Search templates"  Text="{Binding TemplatesFilter, UpdateSourceTrigger=PropertyChanged}" />
                             <ScrollViewer Grid.Row="2" PreviewMouseWheel="ScrollViewer_PreviewMouseWheel">
                                 <ListBox ItemsSource="{Binding TemplatesView}" SelectedValue="{Binding SelectedTemplate}">
                                     <i:Interaction.Triggers>
@@ -256,7 +258,7 @@
                                     </ListBox.GroupStyle>
                                 </ListBox>
                             </ScrollViewer>
-                            <StackPanel Grid.Row="3" Orientation="Horizontal">
+                            <StackPanel Margin="0,5,0,0" Grid.Row="3" Orientation="Horizontal">
                                 <Button Content="_Load" ToolTip="Load the selected template to the input" Command="{Binding LoadTemplateCommand }" />
                             </StackPanel>
                         </Grid>

--- a/src/Lime.Client.TestConsole/Views/SessionView.xaml
+++ b/src/Lime.Client.TestConsole/Views/SessionView.xaml
@@ -56,7 +56,7 @@
                         <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
 
-                    <Label Grid.Row="0" Content="Host" />
+                    <Label Grid.Row="0" Content="Host" FontWeight="Bold" />
                     <TextBox Grid.Row="0" Grid.Column="1" VerticalAlignment="Center" Text="{Binding Host, UpdateSourceTrigger=PropertyChanged}" Grid.ColumnSpan="2" />
 
                     <StackPanel Grid.Row="1" Grid.Column="0"  Margin="0,5" Orientation="Horizontal" Grid.ColumnSpan="2">
@@ -166,7 +166,7 @@
                 <Grid Grid.Row="0" Grid.RowSpan="4" Grid.Column="2">
                     <Grid>
                         <Grid.RowDefinitions>
-                            <RowDefinition Height="200*" />
+                            <RowDefinition Height="Auto" />
                             <RowDefinition Height="200*" />
                             <RowDefinition Height="200*" />
                             <RowDefinition Height="200*" />
@@ -175,44 +175,28 @@
                         <Grid Grid.Row="0">
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />
-                                <RowDefinition Height="*" />
-                                <RowDefinition Height="Auto" />                                
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
                             </Grid.RowDefinitions>
 
-                            <StackPanel Grid.Row="0" Orientation="Horizontal">
-                                <Label Content="Variable Profiles" FontWeight="Bold" />
-                                <Label Content="(Select an entry and hit 'Delete' key to remove)" />
-                            </StackPanel>
-                            
-                            <ScrollViewer Grid.Row="1" PreviewMouseWheel="ScrollViewer_PreviewMouseWheel">
-                                <ListBox ItemsSource="{Binding ProfilesView}" SelectedValue="{Binding SelectedProfile}">
-                                    <ListBox.InputBindings>
-                                        <KeyBinding Command="{Binding DeleteElementProfileCommand}" Key="Delete"/>
-                                    </ListBox.InputBindings>
-                                    <i:Interaction.Triggers>
-                                        <i:EventTrigger EventName="MouseDoubleClick">
-                                            <i:InvokeCommandAction Command="{Binding LoadProfileCommand}" />
-                                        </i:EventTrigger>
-                                    </i:Interaction.Triggers>
-                                    <ListBox.ItemTemplate>
-                                        <DataTemplate>
-                                            <TextBlock Text="{Binding Name}" />
-                                        </DataTemplate>
-                                    </ListBox.ItemTemplate>
-                                    <ListBox.GroupStyle>
-                                        <GroupStyle>
-                                            <GroupStyle.HeaderTemplate>
-                                                <DataTemplate>
-                                                    <TextBlock FontWeight="Bold"  Text="{Binding Name}" />
-                                                </DataTemplate>
-                                            </GroupStyle.HeaderTemplate>
-                                        </GroupStyle>
-                                    </ListBox.GroupStyle>
-                                </ListBox>
-                            </ScrollViewer>
+                            <Label Grid.Row="0" Content="Variable Profiles" FontWeight="Bold" />
 
-                            <StackPanel Grid.Row="2" Margin="0,5,13,0" Orientation="Horizontal" HorizontalAlignment="Right">
+                            <ComboBox Grid.Row="1" ItemsSource="{Binding ProfilesView}" SelectedItem="{Binding SelectedProfile, Mode=TwoWay}" SelectedIndex="{Binding SelectedProfileIndex}" IsTextSearchEnabled="True">
+                                <i:Interaction.Triggers>
+                                    <i:EventTrigger EventName="SelectionChanged">
+                                        <i:InvokeCommandAction Command="{Binding LoadProfileCommand}"></i:InvokeCommandAction>
+                                    </i:EventTrigger>
+                                </i:Interaction.Triggers>
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding Name}" />
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+
+                            <StackPanel Grid.Row="2" Margin="0,5,0,0" Orientation="Horizontal" HorizontalAlignment="Right">
                                 <xctk:WatermarkTextBox Text="{Binding ProfileName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,5,0" MinWidth="125" Watermark="Profile name"></xctk:WatermarkTextBox>
+                                <Button Content="Delete Profile" Command="{Binding DeleteElementProfileCommand}" />
                                 <Button Content="Save Profile" Command="{Binding SaveProfileCommand}" />
                             </StackPanel>
 

--- a/src/Lime.Client.TestConsole/Views/SessionView.xaml
+++ b/src/Lime.Client.TestConsole/Views/SessionView.xaml
@@ -176,12 +176,19 @@
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition Height="*" />
-                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />                                
                             </Grid.RowDefinitions>
 
-                            <Label Grid.Row="0" Content="Variable Profiles" FontWeight="Bold" />
+                            <StackPanel Grid.Row="0" Orientation="Horizontal">
+                                <Label Content="Variable Profiles" FontWeight="Bold" />
+                                <Label Content="(Select an entry and hit 'Delete' key to remove)" />
+                            </StackPanel>
+                            
                             <ScrollViewer Grid.Row="1" PreviewMouseWheel="ScrollViewer_PreviewMouseWheel">
                                 <ListBox ItemsSource="{Binding ProfilesView}" SelectedValue="{Binding SelectedProfile}">
+                                    <ListBox.InputBindings>
+                                        <KeyBinding Command="{Binding DeleteElementProfileCommand}" Key="Delete"/>
+                                    </ListBox.InputBindings>
                                     <i:Interaction.Triggers>
                                         <i:EventTrigger EventName="MouseDoubleClick">
                                             <i:InvokeCommandAction Command="{Binding LoadProfileCommand}" />

--- a/src/Lime.Client.TestConsole/Views/SessionView.xaml
+++ b/src/Lime.Client.TestConsole/Views/SessionView.xaml
@@ -219,7 +219,7 @@
 
                             <Label Grid.Row="0" Content="Variables" FontWeight="Bold" />
                             <ScrollViewer Grid.Row="1" PreviewMouseWheel="ScrollViewer_PreviewMouseWheel">
-                                <DataGrid AutoGenerateColumns="False" ItemsSource="{Binding Variables}">
+                                <DataGrid RowHeaderWidth="0" AutoGenerateColumns="False" ItemsSource="{Binding Variables}">
                                     <DataGrid.Columns>
                                         <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="50*" />
                                         <DataGridTextColumn Header="Value" Binding="{Binding Value}" Width="50*" />

--- a/src/Lime.Client.TestConsole/Views/SessionView.xaml
+++ b/src/Lime.Client.TestConsole/Views/SessionView.xaml
@@ -123,6 +123,7 @@
                                        AcceptsTab="True"
                                        Name="JsonInput"
                                        Text="{Binding InputJson, UpdateSourceTrigger=PropertyChanged}" />
+
                     <StackPanel Grid.Row="1" Margin="0,5" Orientation="Horizontal">
                         <Button Content="_Indent" ToolTip="Indent the JSON input" Command="{Binding IndentCommand}" />
                         <Button Content="_Validate" ToolTip="Validates the JSON input" Command="{Binding ValidateCommand}" />
@@ -179,33 +180,35 @@
                             </Grid.RowDefinitions>
 
                             <Label Grid.Row="0" Content="Variable Profiles" FontWeight="Bold" />
-                            <ListBox Grid.Row="1" ItemsSource="{Binding ProfilesView}" SelectedValue="{Binding SelectedProfile}">
-                                <i:Interaction.Triggers>
-                                    <i:EventTrigger EventName="MouseDoubleClick">
-                                        <i:InvokeCommandAction Command="{Binding LoadProfileCommand}" />
-                                    </i:EventTrigger>
-                                </i:Interaction.Triggers>
-                                <ListBox.ItemTemplate>
-                                    <DataTemplate>
-                                        <TextBlock Text="{Binding Name}" />
-                                    </DataTemplate>
-                                </ListBox.ItemTemplate>
-                                <ListBox.GroupStyle>
-                                    <GroupStyle>
-                                        <GroupStyle.HeaderTemplate>
-                                            <DataTemplate>
-                                                <TextBlock FontWeight="Bold"  Text="{Binding Name}" />
-                                            </DataTemplate>
-                                        </GroupStyle.HeaderTemplate>
-                                    </GroupStyle>
-                                </ListBox.GroupStyle>
-                            </ListBox>
-                            
-                            <StackPanel Grid.Row="2" Margin="0,5" Orientation="Horizontal" HorizontalAlignment="Right">
+                            <ScrollViewer Grid.Row="1" PreviewMouseWheel="ScrollViewer_PreviewMouseWheel">
+                                <ListBox ItemsSource="{Binding ProfilesView}" SelectedValue="{Binding SelectedProfile}">
+                                    <i:Interaction.Triggers>
+                                        <i:EventTrigger EventName="MouseDoubleClick">
+                                            <i:InvokeCommandAction Command="{Binding LoadProfileCommand}" />
+                                        </i:EventTrigger>
+                                    </i:Interaction.Triggers>
+                                    <ListBox.ItemTemplate>
+                                        <DataTemplate>
+                                            <TextBlock Text="{Binding Name}" />
+                                        </DataTemplate>
+                                    </ListBox.ItemTemplate>
+                                    <ListBox.GroupStyle>
+                                        <GroupStyle>
+                                            <GroupStyle.HeaderTemplate>
+                                                <DataTemplate>
+                                                    <TextBlock FontWeight="Bold"  Text="{Binding Name}" />
+                                                </DataTemplate>
+                                            </GroupStyle.HeaderTemplate>
+                                        </GroupStyle>
+                                    </ListBox.GroupStyle>
+                                </ListBox>
+                            </ScrollViewer>
+
+                            <StackPanel Grid.Row="2" Margin="0,5,13,0" Orientation="Horizontal" HorizontalAlignment="Right">
                                 <xctk:WatermarkTextBox Text="{Binding ProfileName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,5,0" MinWidth="125" Watermark="Profile name"></xctk:WatermarkTextBox>
                                 <Button Content="Save Profile" Command="{Binding SaveProfileCommand}" />
                             </StackPanel>
-                            
+
                         </Grid>
 
                         <Grid Grid.Row="1">


### PR DESCRIPTION
# Motivation
The idea in this pull request is to create a collection of variables that we can reuse easily.

Actual days, when we need to use more than one Lime Test Console instance, the last one that was closed will save variables in appdata file.

Besides this, when we need to test different scenarios with different identities, we spent some time to configure this.

So, the idea is to allow users to save this variables snapshots in Profiles and reuse whenever they want.

# Changes
- Create a Profile collection to persist the variables subset
- Create `ListBox` structure to show our current saved profiles
- Create `SaveProfile` logic to, when we close the console, save the content in a file named **`Profiles.json`** in **`AppData`** folder

# Another changes
Also, I improved the scrollbar layout to be more clean :)

## With Dark Mode
![New look](https://user-images.githubusercontent.com/6129653/146077430-93f5f356-e90f-43c0-b810-0fc2b02e2b97.PNG)
![Profiles section](https://user-images.githubusercontent.com/6129653/146077435-064d5d02-3c6c-475c-be71-8d5172b83fd8.PNG)

## Without Dark Mode
![New look - Without Dark Mode](https://user-images.githubusercontent.com/6129653/146078057-9982440c-b933-4ffb-8b3e-c15a29fa6646.PNG)
![Profiles section - Without Dark Mode](https://user-images.githubusercontent.com/6129653/146078060-c0812361-e339-4e62-ab78-9a957f2bdcac.PNG)

# Edit

After @andreminelli hint, I've changed the implementation to use a ComboBox instead a ListView, like the images below
![1 - Profile Section - Empty ComboBox](https://user-images.githubusercontent.com/6129653/146391722-5e0ddb71-0482-4ded-a3f1-92eb13a105ce.PNG)
![2 - Profile Section - Selected element](https://user-images.githubusercontent.com/6129653/146391727-8867b3d4-abbf-4b69-bef6-7fab6fbbc352.PNG)