### PR TITLE
Added the LastUpdateDate field in the Contact, to identify when fields where changed

### DIFF
--- a/src/Lime.Messaging/Resources/Contact.cs
+++ b/src/Lime.Messaging/Resources/Contact.cs
@@ -20,6 +20,7 @@ namespace Lime.Messaging.Resources
         public const string PRIORITY_KEY = "priority";
         public const string GROUP_KEY = "group";
         public const string LAST_MESSAGE_DATE = "lastMessageDate";
+        public const string LAST_UPDATE_DATE = "lastUpdateDate";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Contact"/> class.
@@ -79,6 +80,12 @@ namespace Lime.Messaging.Resources
         /// </summary>
         [DataMember(Name = LAST_MESSAGE_DATE)]
         public DateTimeOffset? LastMessageDate { get; set; }
+
+        /// <summary>
+        /// Indicates the last change date in any contact field.
+        /// </summary>
+        [DataMember(Name = LAST_UPDATE_DATE)]
+        public DateTimeOffset? LastUpdateDate { get; set; }
 
         [IgnoreDataMember]
         string IIdentity.Name => Identity?.Name;


### PR DESCRIPTION
The lastupdatedate variable was added to identify the moment of change in any Contact field.
With this we will identify the moment of the update.