### PR TITLE
AuthorizationRequired property added to Link

### DIFF
--- a/src/Lime.Messaging/Contents/Link.cs
+++ b/src/Lime.Messaging/Contents/Link.cs
@@ -15,6 +15,7 @@ namespace Lime.Messaging.Contents
         public const string PREVIEW_TYPE_KEY = "previewType";
         public const string TITLE_KEY = "title";
         public const string TEXT_KEY = "text";
+        public const string AUTHORIZATION_REQUIRED_KEY = "authorizationRequired";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Link"/> class.
@@ -70,6 +71,12 @@ namespace Lime.Messaging.Contents
         /// </value>
         [DataMember(Name = TEXT_KEY)]
         public string Text { get; set; }
+
+        /// <summary>
+        /// Defines whether authorization is required for the link.
+        /// </summary>
+        [DataMember(Name = AUTHORIZATION_REQUIRED_KEY)]
+        public bool? AuthorizationRequired { get; set; }
 
         /// <summary>
         /// Returns a <see cref="System.String" /> that represents this instance.


### PR DESCRIPTION
In order to implement the new authenticated media flow in client applications of the Iris architecture, in order to maintain compatibility with the public and private media flows (which exist today and will continue to exist in parallel), I am adding a new parameter in the type "Link", from which the client (or sender) of the message can specify that that link requires an authorization or not.

Looking more specifically at the use in the flow of authenticated media, the parameter suggests to the client application that wants to download the media (media-link), that it must pass the authentication token or key of the entity that wants to view the media in the header of the http request, so that the authorization step of this transaction is executed.