### PR TITLE
Add the message direction to the Reply type

### DIFF
--- a/src/Lime.Messaging/Contents/Reply.cs
+++ b/src/Lime.Messaging/Contents/Reply.cs
@@ -45,6 +45,7 @@ namespace Lime.Messaging.Contents
         public const string ID = "id";
         public const string TYPE_KEY = "type";
         public const string VALUE_KEY = "value";
+        public const string DIRECTION_KEY = "direction";
 
         /// <summary>
         /// Gets or sets the identifier of the message being replied to.
@@ -72,5 +73,26 @@ namespace Lime.Messaging.Contents
         /// </value>
         [DataMember(Name = VALUE_KEY)]
         public Document Value { get; set; }
+
+        /// <summary>
+        /// Indicates the direction of the message in the thread.
+        /// </summary>
+        [DataMember(Name = DIRECTION_KEY)]
+        public MessageDirection Direction { get; set; }
+    }
+
+    [DataContract]
+    public enum MessageDirection
+    {
+        /// <summary>
+        /// The message was sent by the thread owner.
+        /// </summary>
+        [EnumMember(Value = "sent")]
+        Sent,
+        /// <summary>
+        /// The message was received by the thread owner.
+        /// </summary>
+        [EnumMember(Value = "received")]
+        Received
     }
 }


### PR DESCRIPTION
In this commit, I added a new field called "direction" to the "InReplyTo" class to enhance the proper display of the sender of the replied message in the "reply" system. This field will contain information about the message direction in the conversation, that is, whether the message was sent by the thread owner ("sent") or received by the thread owner ("received"). Additionally, I created an enum called "MessageDirection" that defines the possible values for the message direction, with "sent" for sent messages and "received" for received messages. This update will enable the Gateway to handle "reply" type messages without needing to call the "/thread" method in the desk.

This enhancement is particularly relevant as it will allow the Gateway to process "reply" messages efficiently, streamlining the communication flow. With this implementation, the system will promptly identify the direction of the messages in the thread, facilitating proper forwarding and display of responses, thereby improving the overall user experience.