### PR TITLE
559839 Adjustments to the Lime Component for Empty Reactions and Message Direction

### DIFF
--- a/src/Lime.Messaging/Contents/MessageDirection.cs
+++ b/src/Lime.Messaging/Contents/MessageDirection.cs
@@ -1,0 +1,19 @@
+﻿using System.Runtime.Serialization;
+
+namespace Lime.Messaging.Contents
+{
+    [DataContract]
+    public enum MessageDirection
+    {
+        /// <summary>
+        /// The message was sent by the thread owner.
+        /// </summary>
+        [EnumMember(Value = "sent")]
+        Sent,
+        /// <summary>
+        /// The message was received by the thread owner.
+        /// </summary>
+        [EnumMember(Value = "received")]
+        Received
+    }
+}


### PR DESCRIPTION
559839 Adjustments to the Lime Component for Empty Reactions and Message Direction

In this commit, adjustments were made to the Lime Component related to reactions and message direction. The changes include:

1. **Reaction Class:**
   - The `Reaction` class now inherits from the `Document` class.
   - The `Reaction` class has two properties:
     - `Emoji`: Represents the emojis associated with the reaction.
     - `InReactionTo`: Represents the reference to the message to which the reaction is associated.

2. **InReactionTo Class:**
   - The `InReactionTo` class represents the document container for the reaction reference.
   - It has properties for the identifier of the reacted-to message (`Id`), the media type of the contained document (`Type`), and the contained document value (`Value`).

3. **Emojis Enum:**
   - The `Emojis` enum represents various chat states using emojis.
   - Each enum member is annotated with the corresponding emoji value.

These adjustments provide better support for handling empty reactions and offer improved message direction within the Lime Component.
