### PR TITLE
fix: use correct activity kind when creating the activity

### DIFF
--- a/src/Lime.Protocol/Tracing/ActivityExtensions.cs
+++ b/src/Lime.Protocol/Tracing/ActivityExtensions.cs
@@ -104,7 +104,7 @@ namespace Lime.Protocol.Tracing
 
             if (Activity.Current != null && !prioritizeDictionaryActivity)
             {
-                return activitySource.StartActivity(name);
+                return activitySource.StartActivity(name, kind);
             }
 
             dictionary.TryGetValue(TraceContext.TraceParent, out var traceParent);
@@ -117,7 +117,7 @@ namespace Lime.Protocol.Tracing
 
             var success = ActivityContext.TryParse(traceParent, traceState, out var resultContext);
 
-            return success ? activitySource.StartActivity(name, kind, resultContext) : activitySource.StartActivity(name);
+            return success ? activitySource.StartActivity(name, kind, resultContext) : activitySource.StartActivity(name, kind);
         }
 
         /// <summary>
@@ -158,7 +158,7 @@ namespace Lime.Protocol.Tracing
                 activity = StartActivity(envelope.Metadata, name, kind, activitySource, prioritizeDictionaryActivity: prioritizeEnvelopeActivity);
             }
 
-            activity ??= activitySource.StartActivity(name);
+            activity ??= activitySource.StartActivity(name, kind);
 
             activity?.SetEnvelopeTags(envelope);
             activity?.InjectTraceParent(envelope);


### PR DESCRIPTION
Notice there is few invalid kinds inside our library

![kind](https://github.com/takenet/lime-csharp/assets/10624972/540c8449-7b5c-4968-bc0d-d081e55ac1fd)
