### PR TITLE
fix: activity context propagation on channel sender and receiver

### DIFF
--- a/src/Lime.Protocol/Network/ReceiverChannel.cs
+++ b/src/Lime.Protocol/Network/ReceiverChannel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Channels;
@@ -111,7 +112,14 @@ namespace Lime.Protocol.Network
             {
                 if (_receiveFromTransportTask == null)
                 {
+                    var currentActivity = Activity.Current;
+                    Activity.Current = null;
+
+                    // When new tasks are created, the ExecutionContext is captured.
+                    // We should not capture the current activity to start a listener, to avoid incorrect activity propagation.
                     _receiveFromTransportTask = Task.Run(ReceiveFromTransportAsync);
+
+                    Activity.Current = currentActivity;
                 }
             }
             finally

--- a/src/Lime.Protocol/Network/SenderChannel.cs
+++ b/src/Lime.Protocol/Network/SenderChannel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Channels;
@@ -101,7 +102,14 @@ namespace Lime.Protocol.Network
             {
                 if (_sendToTransportTask == null)
                 {
+                    var currentActivity = Activity.Current;
+                    Activity.Current = null;
+
+                    // When new tasks are created, the ExecutionContext is captured.
+                    // We should not capture the current activity to start a listener, to avoid incorrect activity propagation.
                     _sendToTransportTask = Task.Run(SendToTransportAsync);
+
+                    Activity.Current = currentActivity;
                 }
             }
             finally


### PR DESCRIPTION
When starting the channel receiver and sender, the context should not have a active activity because it would be propagated when receiving/sending envelopes, making all received envelopes to be child of the same transaction.

![image](https://github.com/takenet/lime-csharp/assets/10624972/9588a6a4-4d93-4ee7-a860-24194d0b01f9)
