### PR TITLE
Add DiscreteTypes class with Voice and Sticker types. Update Event enum with "deleted" status.

### DIFF
--- a/src/Lime.Protocol/MediaType.cs
+++ b/src/Lime.Protocol/MediaType.cs
@@ -221,6 +221,10 @@ namespace Lime.Protocol
             public static string Audio = "audio";
 
             public static string Video = "video";
+
+            public static string Voice = "voice";
+
+            public static string Sticker = "sticker";
         }
 
         public static class CompositeTypes

--- a/src/Lime.Protocol/Notification.cs
+++ b/src/Lime.Protocol/Notification.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.Serialization;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Lime.Protocol
 {
@@ -95,6 +91,12 @@ namespace Lime.Protocol
         /// The node has consumed the content of the message.
         /// </summary>
         [EnumMember(Value = "consumed")]
-        Consumed
+        Consumed,
+
+        /// <summary>
+        /// The message has been deleted.
+        /// </summary>
+        [EnumMember(Value = "deleted")]
+        Deleted
     }
 }


### PR DESCRIPTION
In this commit, the DiscreteTypes class is updated to include the Voice and Sticker types. These types can be used to represent specific content types in the Lime Protocol.

Additionally, the Event enum is updated to include a new status called "deleted". This status can be used to indicate that a message has been deleted.

These changes enhance the DiscreteTypes class by adding support for Voice and Sticker types, and also improve the Event enum by including the "deleted" status.