### PR TITLE
Implement the Copy and Paste component in Lime Messaging.

### DIFF
--- a/src/Lime.Messaging/Contents/CopyAndPaste.cs
+++ b/src/Lime.Messaging/Contents/CopyAndPaste.cs
@@ -1,0 +1,73 @@
+﻿using Lime.Protocol;
+using System.Runtime.Serialization;
+
+namespace Lime.Messaging.Contents
+{
+    /// <summary>
+    /// Represents a copy and paste document.
+    /// </summary>
+    [DataContract(Namespace = "http://limeprotocol.org/2014")]
+    public class CopyAndPaste : Document
+    {
+        public const string MIME_TYPE = "application/vnd.lime.copy-and-paste+json";
+        public const string HEADER_KEY = "header";
+        public const string FOOTER_KEY = "footer";
+        public const string BUTTON_KEY = "button";
+        public const string BODY_KEY = "body";
+
+        public static readonly MediaType MediaType = MediaType.Parse(MIME_TYPE);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CopyAndPaste"/> class.
+        /// </summary>
+        public CopyAndPaste()
+            : base(MediaType)
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the title of the copy and paste document.
+        /// </summary>
+        [DataMember(Name = HEADER_KEY)]
+        public string Header { get; set; }
+        /// <summary>
+        /// Gets or sets the body of the copy and paste document.
+        /// </summary>
+        [DataMember(Name = BODY_KEY)]
+        public string Body { get; set; }
+
+        /// <summary>
+        /// Gets or sets the footer of the copy and paste document.
+        /// </summary>
+        [DataMember(Name = FOOTER_KEY)]
+        public string Footer { get; set; }
+
+        /// <summary>
+        /// Gets or sets the button of the copy and paste document.
+        /// </summary>
+        [DataMember(Name = BUTTON_KEY)]
+        public Button Button { get; set; }
+    }
+
+    /// <summary>
+    /// Represents a button in a copy and paste document.
+    /// </summary>
+    [DataContract(Namespace = "http://limeprotocol.org/2014")]
+    public class Button
+    {
+        public const string TEXT_KEY = "text";
+        public const string VALUE_KEY = "value";
+
+        /// <summary>
+        /// Gets or sets the text of the button.
+        /// </summary>
+        [DataMember(Name = TEXT_KEY)]
+        public string Text { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value of the button.
+        /// </summary>
+        [DataMember(Name = VALUE_KEY)]
+        public string Value { get; set; }
+    }
+}


### PR DESCRIPTION
The CopyAndPaste class represents a copy and paste document in the Lime messaging protocol. It is used to send structured content that can be copied and pasted by the user. 

The class has the following properties:

- Header: Represents the header of the copy and paste document.
- Body: Represents the body of the copy and paste document.
- Footer: Represents the footer of the copy and paste document.
- Button: Represents a button in the copy and paste document, which can be used for actions or additional information.

The Button class represents a button in the copy and paste document. It has the following properties:

- Text: Represents the text displayed on the button.
- Value: Represents the value associated with the button.

![image](https://github.com/takenet/lime-csharp/assets/8922023/8aa4de17-1056-4646-8335-767795b32c44)
![image](https://github.com/takenet/lime-csharp/assets/8922023/72560183-8ec0-4aa8-b81a-873c097f2010)


The CopyAndPaste class is serialized to JSON using the DataContract attribute and the DataMember attribute is used to specify the JSON key names for the properties. The MediaType constant represents the MIME type of the copy and paste document.