### PR TITLE
add None as a TLS option

### DIFF
--- a/src/Lime.Transport.Tcp/PipeTcpTransport.cs
+++ b/src/Lime.Transport.Tcp/PipeTcpTransport.cs
@@ -1,4 +1,10 @@
+using Lime.Protocol;
+using Lime.Protocol.Network;
+using Lime.Protocol.Security;
+using Lime.Protocol.Serialization;
+using Lime.Protocol.Serialization.Newtonsoft;
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -8,13 +14,6 @@ using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
-using Lime.Protocol;
-using Lime.Protocol.Network;
-using Lime.Protocol.Security;
-using Lime.Protocol.Serialization;
-using Lime.Protocol.Serialization.Newtonsoft;
-using System.Buffers;
-using System.Text;
 using System.Threading.Tasks.Dataflow;
 
 namespace Lime.Transport.Tcp
@@ -268,7 +267,7 @@ namespace Lime.Transport.Tcp
                                 .AuthenticateAsServerAsync(
                                     _serverCertificate,
                                     true,
-                                    SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12,
+                                    SslProtocols.Tls | SslProtocols.Tls11 | SslProtocols.Tls12 | SslProtocols.None,
                                     false)
                                 .WithCancellation(cancellationToken)
                                 .ConfigureAwait(false);


### PR DESCRIPTION
After .net 8, TLS1.3 is enforced as the sslOption. Lime c# is at standard2.1 and it does not have it as an option to expand this selections, So we added none, which says:

"Allows the operating system to choose the best protocol to use, and to block protocols that are not secure. Unless your app has a specific reason not to, you should use this field."

https://learn.microsoft.com/en-us/dotnet/api/system.security.authentication.sslprotocols?view=netstandard-2.1 