### PR TITLE
Adding external message lime type

### DIFF
--- a/src/Lime.Messaging/Contents/External.cs
+++ b/src/Lime.Messaging/Contents/External.cs
@@ -1,0 +1,37 @@
+﻿using Lime.Protocol;
+using System.Runtime.Serialization;
+
+namespace Lime.Messaging.Contents
+{
+    /// <summary>
+    /// Represents an external message.
+    /// </summary>
+    [DataContract]
+    public class External : Document
+    {
+        public static readonly string MimeType = "application/vnd.lime.external+json";
+        public static readonly MediaType MediaType = MediaType.Parse(MimeType);
+
+        public const string TYPE_KEY = "type";
+        public const string CONTENT_KEY = "content";
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Contents.External"/> class.
+        /// </summary>
+        public External()
+            : base(MediaType)
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the type of external message content type.
+        /// </summary>
+        [DataMember(Name = TYPE_KEY)]
+        public MediaType Type => Content?.GetMediaType();
+
+        /// <summary>
+        /// Gets or sets the type of external message content.
+        /// </summary>
+        [DataMember(Name = CONTENT_KEY)]
+        public Document Content { get; set; }
+    }
+}

--- a/src/Lime.Protocol.UnitTests/Serialization/Newtonsoft/EnvelopeSerializerTests.cs
+++ b/src/Lime.Protocol.UnitTests/Serialization/Newtonsoft/EnvelopeSerializerTests.cs
@@ -1115,6 +1115,49 @@ namespace Lime.Protocol.UnitTests.Serialization.Newtonsoft
 
         [Test]
         [Category("Serialize")]
+        public void Serialize_ExternalMessage_ReturnsValidJsonString()
+        {
+            var target = GetTarget();
+
+            var content = Dummy.CreateTextContent();
+
+            var external = new External
+            {
+                Content = content,
+            };
+
+            var message = Dummy.CreateMessage(external);
+            message.Pp = Dummy.CreateNode();
+
+            var metadataKey1 = "randomString1";
+            var metadataValue1 = Dummy.CreateRandomString(50);
+            var metadataKey2 = "randomString2";
+            var metadataValue2 = Dummy.CreateRandomString(50);
+            message.Metadata = new Dictionary<string, string>
+            {
+                { metadataKey1, metadataValue1 },
+                { metadataKey2, metadataValue2 }
+            };
+
+            var resultString = target.Serialize(message);
+            Assert.IsTrue(resultString.HasValidJsonStackedBrackets());
+            Assert.IsTrue(resultString.ContainsJsonProperty(Envelope.ID_KEY, message.Id));
+            Assert.IsTrue(resultString.ContainsJsonProperty(Envelope.FROM_KEY, message.From));
+            Assert.IsTrue(resultString.ContainsJsonProperty(Envelope.PP_KEY, message.Pp));
+            Assert.IsTrue(resultString.ContainsJsonProperty(Envelope.TO_KEY, message.To));
+            Assert.IsTrue(resultString.ContainsJsonProperty(Message.TYPE_KEY, message.Content.GetMediaType()));
+            Assert.IsTrue(resultString.ContainsJsonKey(Message.CONTENT_KEY));
+            Assert.IsTrue(resultString.ContainsJsonKey(Message.TYPE_KEY));
+            Assert.IsTrue(resultString.ContainsJsonProperty(metadataKey1, metadataValue1));
+            Assert.IsTrue(resultString.ContainsJsonProperty(metadataKey2, metadataValue2));
+
+            var dictionary = JsonConvert.DeserializeObject<Dictionary<string, object>>(resultString, target.Settings);
+            var externalObject = dictionary[Message.CONTENT_KEY].ShouldBeAssignableTo<JObject>();
+            var contentObject = externalObject[External.CONTENT_KEY].ShouldBeAssignableTo<JValue>();
+        }
+
+        [Test]
+        [Category("Serialize")]
         public void Serialize_CopyAndPasteMessage_ReturnsValidJsonString()
         {
             var target = GetTarget();
@@ -2666,6 +2709,49 @@ namespace Lime.Protocol.UnitTests.Serialization.Newtonsoft
             Assert.AreEqual(text2, reactionToText.Text);
             Assert.AreEqual((MessageDirection)messageDireaction, reaction.InReactionTo.Direction);
             Assert.AreEqual(emojis.ToString(), reaction.Emoji.ToString());
+        }
+
+        [Test]
+        [Category("Deserialize")]
+        public void Deserialize_ExternalJsonMessage_ReturnsJsonDocument()
+        {
+            // Arrange
+            var target = GetTarget();
+
+            var id = EnvelopeId.NewId();
+            var from = Dummy.CreateNode();
+            var pp = Dummy.CreateNode();
+            var to = Dummy.CreateNode();
+            var type = PlainText.MIME_TYPE;
+
+            string randomKey1 = "randomString1";
+            string randomKey2 = "randomString2";
+            string randomString1 = Dummy.CreateRandomStringExtended(50);
+            string randomString2 = Dummy.CreateRandomStringExtended(50);
+            string text = Dummy.CreateRandomStringExtended(50);
+
+            string json =
+                $"{{\"id\":\"{id}\",\"to\":\"{to}\",\"from\":\"{@from}\",\"pp\":\"{pp}\",\"type\":\"{External.MimeType.Escape()}\",\"metadata\":{{\"{randomKey1}\":\"{randomString1.Escape()}\",\"{randomKey2}\":\"{randomString2.Escape()}\"}},\"content\":{{\"type\":\"{type.Escape()}\",\"content\":\"{text.Escape()}\"}}}}";
+
+            var envelope = target.Deserialize(json);
+
+            var message = envelope.ShouldBeOfType<Message>();
+            Assert.AreEqual(id, message.Id);
+            Assert.AreEqual(from, message.From);
+            Assert.AreEqual(pp, message.Pp);
+            Assert.AreEqual(to, message.To);
+            Assert.IsNotNull(message.Metadata);
+            Assert.IsTrue(message.Metadata.ContainsKey(randomKey1));
+            Assert.AreEqual(message.Metadata[randomKey1], randomString1);
+            Assert.IsTrue(message.Metadata.ContainsKey(randomKey2));
+            Assert.AreEqual(message.Metadata[randomKey2], randomString2);
+
+            message.Content.ShouldBeOfType<External>();
+
+            var external = (External)message.Content;
+
+            var externalText = external.Content.ShouldBeOfType<PlainText>();
+            Assert.AreEqual(text, externalText.Text);
         }
 
         [Test]


### PR DESCRIPTION
New lime message type called External.

This new type will represent messages that are being sent through your platform but belong to a third member (not part of any group).

This will encapsulate another document that can be of any other document type.