### PR TITLE
fix: adjust pipeline vm usage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,9 @@ trigger:
 - main
 - beta/*
 
+pool:
+  vmImage: ubuntu-22.04
+
 name: 0.12$(Rev:.r)
   
 variables:


### PR DESCRIPTION
This pull request updates the Azure Pipelines configuration to specify the virtual machine image used for the build process.

Pipeline configuration changes:

* [`azure-pipelines.yml`](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5R6-R8): Added a `pool` configuration specifying `vmImage: ubuntu-22.04` to define the virtual machine image for the pipeline.