### PR TITLE
feat: add new fields to ContactDocument

### DIFF
--- a/src/Lime.Client.Windows/Lime.Client.Windows.csproj
+++ b/src/Lime.Client.Windows/Lime.Client.Windows.csproj
@@ -112,7 +112,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="SmartFormat, Version=2.0.0.0, Culture=neutral, PublicKeyToken=568866805651201f, processorArchitecture=MSIL">

--- a/src/Lime.Client.Windows/Lime.Client.Windows.csproj
+++ b/src/Lime.Client.Windows/Lime.Client.Windows.csproj
@@ -111,8 +111,8 @@
       <HintPath>..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="SmartFormat, Version=2.0.0.0, Culture=neutral, PublicKeyToken=568866805651201f, processorArchitecture=MSIL">

--- a/src/Lime.Client.Windows/packages.config
+++ b/src/Lime.Client.Windows/packages.config
@@ -10,7 +10,7 @@
   <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net461" />
   <package id="ModernUI.WPF.NoBackButton" version="1.0.5.1-alpha" targetFramework="net461" />
   <package id="MvvmLightLibs" version="4.4.32.7" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net461" />
   <package id="SmartFormat.NET" version="2.0.0.0" targetFramework="net461" />
   <package id="SslCertBinding.Net" version="1.0.2" targetFramework="net461" />
   <package id="StackExchange.Redis" version="1.1.608" targetFramework="net461" />

--- a/src/Lime.Client.Windows/packages.config
+++ b/src/Lime.Client.Windows/packages.config
@@ -10,7 +10,7 @@
   <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net461" />
   <package id="ModernUI.WPF.NoBackButton" version="1.0.5.1-alpha" targetFramework="net461" />
   <package id="MvvmLightLibs" version="4.4.32.7" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net461" />
   <package id="SmartFormat.NET" version="2.0.0.0" targetFramework="net461" />
   <package id="SslCertBinding.Net" version="1.0.2" targetFramework="net461" />
   <package id="StackExchange.Redis" version="1.1.608" targetFramework="net461" />

--- a/src/Lime.Messaging/Resources/ContactDocument.cs
+++ b/src/Lime.Messaging/Resources/ContactDocument.cs
@@ -179,7 +179,7 @@ namespace Lime.Messaging.Resources
         /// The phone number of the contact in Meta (WhatsApp ID).
         /// </summary>
         [DataMember(Name = WHATSAPP_WA_ID_KEY)]
-        public string? WhatsAppWaId { get; set; }
+        public long? WhatsAppWaId { get; set; }
 
         /// <summary>
         /// The user-chosen identifier of the contact in Meta.

--- a/src/Lime.Messaging/Resources/ContactDocument.cs
+++ b/src/Lime.Messaging/Resources/ContactDocument.cs
@@ -32,6 +32,10 @@ namespace Lime.Messaging.Resources
         public const string CREATION_DATE_KEY = "creationDate";
         public const string TENANT_ID_KEY = "tenantId";
         public const string IS_GROUP_ENABLED_KEY = "isGroupEnabled";
+        public const string WHATSAPP_BSUID_KEY = "whatsAppBsuid";
+        public const string WHATSAPP_WA_ID_KEY = "whatsAppWaId";
+        public const string WHATSAPP_USER_NAME_KEY = "whatsAppUserName";
+        public const string WHATSAPP_PARENT_ID_KEY = "whatsAppParentId";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ContactDocument"/> class.
@@ -164,6 +168,30 @@ namespace Lime.Messaging.Resources
         /// </summary>
         [DataMember(Name = IS_GROUP_ENABLED_KEY)]
         public bool? IsGroupEnabled { get; set; }
+
+        /// <summary>
+        /// The unique identifier of the contact in Meta (Business Scoped User ID).
+        /// </summary>
+        [DataMember(Name = WHATSAPP_BSUID_KEY)]
+        public string? WhatsAppBsuid { get; set; }
+
+        /// <summary>
+        /// The phone number of the contact in Meta (WhatsApp ID).
+        /// </summary>
+        [DataMember(Name = WHATSAPP_WA_ID_KEY)]
+        public string? WhatsAppWaId { get; set; }
+
+        /// <summary>
+        /// The user-chosen identifier of the contact in Meta (e.g., Instagram handle).
+        /// </summary>
+        [DataMember(Name = WHATSAPP_USER_NAME_KEY)]
+        public string? WhatsAppUserName { get; set; }
+
+        /// <summary>
+        /// The identifier linking the contact to a Company in Meta.
+        /// </summary>
+        [DataMember(Name = WHATSAPP_PARENT_ID_KEY)]
+        public string? WhatsAppParentId { get; set; }
     }
 
     /// <summary>

--- a/src/Lime.Messaging/Resources/ContactDocument.cs
+++ b/src/Lime.Messaging/Resources/ContactDocument.cs
@@ -182,7 +182,7 @@ namespace Lime.Messaging.Resources
         public string? WhatsAppWaId { get; set; }
 
         /// <summary>
-        /// The user-chosen identifier of the contact in Meta (e.g., Instagram handle).
+        /// The user-chosen identifier of the contact in Meta.
         /// </summary>
         [DataMember(Name = WHATSAPP_USER_NAME_KEY)]
         public string? WhatsAppUserName { get; set; }


### PR DESCRIPTION
This pull request updates the `Lime.Client.Windows` project to use a newer version of the `Newtonsoft.Json` library and extends the `ContactDocument` class in `Lime.Messaging` to support additional WhatsApp-related metadata fields. These changes improve compatibility with newer dependencies and enhance the application's ability to store and manage WhatsApp-specific contact information.

Dependency upgrade:

* Upgraded `Newtonsoft.Json` from version 9.0.1 to 13.0.1 in both `packages.config` and the project file, ensuring compatibility with newer features and security updates. [[1]](diffhunk://#diff-05ee5994ea3a8b94d09bc690192a91e2cd96c1bfa5174d7187846a008408b644L13-R13) [[2]](diffhunk://#diff-aeef7c173d1bec5965b704461419cc206a4c1a0e64edbe0bc8efadd73414fb05L114-R115)

WhatsApp metadata support in contacts:

* Added four new constant keys to `ContactDocument` for WhatsApp-specific fields: `whatsAppBsuid`, `whatsAppWaId`, `whatsAppUserName`, and `whatsAppParentId`.
* Introduced corresponding nullable properties (`WhatsAppBsuid`, `WhatsAppWaId`, `WhatsAppUserName`, `WhatsAppParentId`) with data member attributes to allow serialization and storage of these WhatsApp metadata fields in contact documents.