### PR TITLE
feat: whatsappwaid to string

### DIFF
--- a/src/Lime.Messaging/Resources/ContactDocument.cs
+++ b/src/Lime.Messaging/Resources/ContactDocument.cs
@@ -173,25 +173,25 @@ namespace Lime.Messaging.Resources
         /// The unique identifier of the contact in Meta (Business Scoped User ID).
         /// </summary>
         [DataMember(Name = WHATSAPP_BSUID_KEY)]
-        public string? WhatsAppBsuid { get; set; }
+        public string WhatsAppBsuid { get; set; }
 
         /// <summary>
         /// The phone number of the contact in Meta (WhatsApp ID).
         /// </summary>
         [DataMember(Name = WHATSAPP_WA_ID_KEY)]
-        public long? WhatsAppWaId { get; set; }
+        public string WhatsAppWaId { get; set; }
 
         /// <summary>
         /// The user-chosen identifier of the contact in Meta.
         /// </summary>
         [DataMember(Name = WHATSAPP_USER_NAME_KEY)]
-        public string? WhatsAppUserName { get; set; }
+        public string WhatsAppUserName { get; set; }
 
         /// <summary>
         /// The identifier linking the contact to a Company in Meta.
         /// </summary>
         [DataMember(Name = WHATSAPP_PARENT_ID_KEY)]
-        public string? WhatsAppParentId { get; set; }
+        public string WhatsAppParentId { get; set; }
     }
 
     /// <summary>


### PR DESCRIPTION
This pull request updates the `ContactDocument` class in `ContactDocument.cs` by changing the types of several WhatsApp-related properties from nullable types to non-nullable strings. This change enforces that these fields must always have a value, improving data consistency.

**Type safety and data consistency improvements:**

* Changed `WhatsAppBsuid`, `WhatsAppWaId`, `WhatsAppUserName`, and `WhatsAppParentId` properties from nullable (`string?`/`long?`) to non-nullable `string`, ensuring these properties are always set. (`[src/Lime.Messaging/Resources/ContactDocument.csL176-R194](diffhunk://#diff-67e683afd10ce2b89d7c0b1a9603f7b610a1e3479c19ba8fa33e6be346e6c6c4L176-R194)`)